### PR TITLE
feat: improve 14 skills: expanded descriptions, workflows, & metadata

### DIFF
--- a/plugins/notes/skills/sqlite-db/SKILL.md
+++ b/plugins/notes/skills/sqlite-db/SKILL.md
@@ -1,35 +1,15 @@
 ---
 name: sqlite-db
-description: General guide for using the sqlite3 CLI to build composable knowledge databases. Use this skill when creating SQLite databases, designing schemas, querying data, managing relationships, or building new sqlite-based domain skills. Provides the foundational patterns that all specialized sqlite skills build upon.
+description: General guide for using the sqlite3 CLI to build composable knowledge databases. Use this skill when creating SQLite databases, designing schemas with CREATE TABLE, defining foreign keys and indexes, running CLI queries, importing or exporting data (CSV/JSON), managing structural and graph relationships, or building new sqlite-based domain skills. Provides foundational patterns — for domain-specific workflows (e.g., a notes or task tracker schema), prefer a dedicated sqlite domain skill if one exists; use this skill for general-purpose sqlite operations and cross-domain patterns.
 ---
 
 # SQLite Database Skills
 
 **Composable knowledge databases via raw SQL.**
 
-SQLite databases are portable, self-contained, and require no server. The `sqlite3` CLI provides direct access to the full power of relational SQL: indexes, joins, aggregations, window functions, CTEs, full-text search, JSON functions, triggers, and views. This skill teaches agents how to use SQLite as a knowledge management substrate.
-
-## Philosophy
-
-### SQL is the Interface
-
-No wrapper, no abstraction layer. You compose SQL directly. This gives you the full power of SQLite: complex joins, window functions, CTEs, FTS5, JSON operations, triggers, and views. Verbosity costs tokens, not keystrokes — and the expressiveness pays dividends.
-
-### Schemas Are the DDL
-
-No YAML declarations. The `CREATE TABLE` statements *are* the schema. Run `.schema` to see everything. Column types, constraints, foreign keys, indexes — all visible in the DDL. Self-documenting by design.
-
-### Composable .db Files
-
-Each domain gets its own `.db` file. Your notes database, investment tracker, and issue tracker are separate files. Portable — copy, share, back up independently. No central server required.
-
-### Agent-Compatible
-
-The `sqlite3` CLI is deterministic and stateless per invocation. Output modes (`-header -column`, `.mode json`, `-line`) are parseable. Commands never rely on session state. Perfect for LLM-driven workflows.
+The `sqlite3` CLI provides direct access to the full power of relational SQL: indexes, joins, aggregations, window functions, CTEs, full-text search, JSON functions, triggers, and views. Each domain gets its own `.db` file. Always pass the database path explicitly — stateless, deterministic per invocation.
 
 ## Database Targeting
-
-**Always pass the database path as the first argument to `sqlite3`.** This ensures stateless, deterministic behavior.
 
 ```bash
 # Single-line command
@@ -46,42 +26,34 @@ SQL
 
 ## Output Modes
 
-Choose the output mode based on your needs:
-
-| Mode | Use Case | Invocation |
-|------|----------|------------|
-| **Column** | Human-readable tables | `sqlite3 -header -column mydata.db "SELECT ..."` |
-| **JSON** | Agent parsing with jq | `sqlite3 mydata.db "SELECT ..." \| jq` (after `.mode json`) |
-| **CSV** | Export to spreadsheets | `sqlite3 -csv -header mydata.db "SELECT ..."` |
-| **Line** | Single record inspection | `sqlite3 -line mydata.db "SELECT * FROM notes WHERE id = 'NOTE-...';"` |
-
-### JSON Mode Example
+Use **column mode** for human-readable output and **JSON mode** for scripting:
 
 ```bash
-# Enable JSON output and query
+# Human-readable (column mode)
+sqlite3 -header -column /path/to/mydata.db "SELECT id, title, status FROM notes LIMIT 10;"
+
+# JSON for scripting/piping to jq
 sqlite3 /path/to/mydata.db <<'SQL'
 .mode json
-SELECT id, title, tags FROM notes LIMIT 5;
+SELECT id, title, tags FROM notes WHERE status = 'active';
 SQL
-```
 
-Then pipe to `jq` for filtering or transformation:
-
-```bash
 sqlite3 /path/to/mydata.db "SELECT ..." | jq -r '.[] | select(.status == "active") | .id'
+
+# Single record inspection (-line mode)
+sqlite3 -line /path/to/mydata.db "SELECT * FROM notes WHERE id = 'NOTE-...';"
+
+# CSV export
+sqlite3 -csv -header /path/to/mydata.db "SELECT ..." > export.csv
 ```
 
 ## Core Operations
 
 ### Initialize a Database
 
-Create the database directory and initialize tables with constraints and pragmas:
-
 ```bash
-# Create directory
 mkdir -p /path/to/.sqlite
 
-# Initialize database with pragmas and schema
 sqlite3 /path/to/.sqlite/mydata.db <<'SQL'
 PRAGMA journal_mode = WAL;
 PRAGMA foreign_keys = ON;
@@ -117,17 +89,9 @@ Use inline SQL expressions to generate unique, time-ordered, human-readable IDs:
 - `'NOTE-' || strftime('%Y%m%d', 'now') || '-' || lower(hex(randomblob(4)))` → `NOTE-20260208-a3f8c291`
 - `'TASK-' || strftime('%Y%m%d', 'now') || '-' || lower(hex(randomblob(4)))` → `TASK-20260208-7b2e9f41`
 
-**Prefix conventions:**
-- Notes: `NOTE-`
-- Tasks: `TASK-`
-- Resources: `RES-`
-- Clippings: `CLIP-`
-- Breadcrumbs: `CRUMB-`
-- Reflections: `REFL-`
+**Prefix conventions:** `NOTE-`, `TASK-`, `RES-`, `CLIP-`, `CRUMB-`, `REFL-`
 
 ### Create Records
-
-Insert records with inline ID generation:
 
 ```bash
 sqlite3 /path/to/.sqlite/mydata.db <<'SQL'
@@ -147,7 +111,6 @@ SQL
 ### Query Records
 
 ```bash
-# Simple query with filtering and ordering
 sqlite3 -header -column /path/to/.sqlite/mydata.db <<'SQL'
 SELECT id, title, status, created_at
 FROM notes
@@ -157,7 +120,7 @@ LIMIT 10;
 SQL
 ```
 
-**Pagination example:**
+**Pagination:**
 
 ```sql
 SELECT id, title
@@ -177,12 +140,8 @@ SQL
 
 ### Show a Record
 
-Use `-line` mode for human-readable single-record display:
-
 ```bash
-sqlite3 -line /path/to/.sqlite/mydata.db <<'SQL'
-SELECT * FROM notes WHERE id = 'NOTE-20260208-a3f8c291';
-SQL
+sqlite3 -line /path/to/.sqlite/mydata.db "SELECT * FROM notes WHERE id = 'NOTE-20260208-a3f8c291';"
 ```
 
 Output:
@@ -198,6 +157,10 @@ updated_at = 2026-02-08 14:32:01
 
 ### Update Records
 
+**Workflow:**
+
+1. Run the UPDATE:
+
 ```bash
 sqlite3 /path/to/.sqlite/mydata.db <<'SQL'
 UPDATE notes
@@ -208,7 +171,21 @@ WHERE id = 'NOTE-20260208-a3f8c291';
 SQL
 ```
 
-**Batch update example:**
+2. Verify the change before proceeding:
+
+```bash
+sqlite3 -line /path/to/.sqlite/mydata.db "SELECT id, status, updated_at FROM notes WHERE id = 'NOTE-20260208-a3f8c291';"
+```
+
+**Batch update — always verify row counts:**
+
+1. Preview rows affected:
+
+```sql
+SELECT COUNT(*) FROM notes WHERE created_at < date('now', '-1 year');
+```
+
+2. Run the batch update:
 
 ```sql
 UPDATE notes
@@ -216,13 +193,35 @@ SET status = 'archived', updated_at = datetime('now')
 WHERE created_at < date('now', '-1 year');
 ```
 
+3. Confirm results:
+
+```sql
+SELECT status, COUNT(*) FROM notes GROUP BY status;
+```
+
 ### Delete Records
 
+**Workflow:**
+
+1. Preview what will be deleted:
+
 ```bash
-sqlite3 /path/to/.sqlite/mydata.db <<'SQL'
-DELETE FROM notes WHERE id = 'NOTE-20260208-a3f8c291';
-SQL
+sqlite3 /path/to/.sqlite/mydata.db "SELECT id, title FROM notes WHERE id = 'NOTE-20260208-a3f8c291';"
 ```
+
+2. Run the DELETE:
+
+```bash
+sqlite3 /path/to/.sqlite/mydata.db "DELETE FROM notes WHERE id = 'NOTE-20260208-a3f8c291';"
+```
+
+3. Verify deletion (must return 0):
+
+```bash
+sqlite3 /path/to/.sqlite/mydata.db "SELECT COUNT(*) FROM notes WHERE id = 'NOTE-20260208-a3f8c291';"
+```
+
+Only proceed with downstream operations once count confirms 0.
 
 ## Relationships
 
@@ -236,7 +235,7 @@ Use foreign key columns for parent-child ownership and 1:1 or N:1 relationships:
 CREATE TABLE clippings (
   id TEXT PRIMARY KEY,
   content TEXT NOT NULL,
-  resource_id TEXT,  -- Foreign key to resources table
+  resource_id TEXT,
   clipped_at TEXT NOT NULL DEFAULT (datetime('now')),
   FOREIGN KEY (resource_id) REFERENCES resources(id) ON DELETE CASCADE
 );
@@ -327,40 +326,29 @@ WHERE source_id = 'NOTE-20260208-a3f8c291'
 
 ## Views as Saved Queries
 
-Views are more powerful than memhub's saved queries — they can use joins, aggregations, and reference other views.
-
-### Create a View
+Views support joins, aggregations, and can reference other views.
 
 ```sql
+-- Create
 CREATE VIEW active_notes AS
 SELECT id, title, status, created_at
 FROM notes
 WHERE status = 'active'
 ORDER BY created_at DESC;
-```
 
-### Query a View
-
-```sql
+-- Query
 SELECT * FROM active_notes LIMIT 10;
-```
 
-### List All Views
-
-```sql
+-- List all views
 SELECT name FROM sqlite_master WHERE type = 'view';
-```
 
-### Drop a View
-
-```sql
+-- Drop
 DROP VIEW IF EXISTS active_notes;
 ```
 
-### Complex View Example
+**Complex view example — note graph with link counts:**
 
 ```sql
--- Note graph view with link counts
 CREATE VIEW note_graph AS
 SELECT
   n.id,
@@ -376,8 +364,6 @@ GROUP BY n.id, n.title, n.status;
 
 ## Triggers for Automation
 
-Triggers automate repetitive tasks like timestamp updates and FTS synchronization.
-
 ### Auto-Update Timestamps
 
 ```sql
@@ -391,11 +377,9 @@ END;
 
 ### FTS Sync Triggers
 
-See "Full-Text Search" section below for complete examples.
+See "Full-Text Search" section below.
 
 ## Full-Text Search (FTS5)
-
-SQLite's FTS5 extension provides ranked full-text search. Memhub cannot do this.
 
 ### Create FTS Virtual Table
 
@@ -412,23 +396,18 @@ CREATE VIRTUAL TABLE notes_fts USING fts5(
 
 ### Sync Triggers
 
-Keep the FTS index synchronized with the base table:
-
 ```sql
--- Trigger: insert
 CREATE TRIGGER notes_fts_insert AFTER INSERT ON notes BEGIN
   INSERT INTO notes_fts(rowid, id, title, body, tags)
   VALUES (NEW.rowid, NEW.id, NEW.title, NEW.body, NEW.tags);
 END;
 
--- Trigger: update
 CREATE TRIGGER notes_fts_update AFTER UPDATE ON notes BEGIN
   UPDATE notes_fts
   SET title = NEW.title, body = NEW.body, tags = NEW.tags
   WHERE rowid = OLD.rowid;
 END;
 
--- Trigger: delete
 CREATE TRIGGER notes_fts_delete AFTER DELETE ON notes BEGIN
   DELETE FROM notes_fts WHERE rowid = OLD.rowid;
 END;
@@ -461,23 +440,17 @@ LIMIT 10;
 
 ## JSON Functions
 
-SQLite provides robust JSON support for array and object fields.
-
-### Creating JSON Arrays
+### Creating and Querying JSON Arrays
 
 ```sql
--- Inline array
+-- Store as JSON array
 INSERT INTO notes (id, title, tags)
 VALUES (
   'NOTE-' || strftime('%Y%m%d', 'now') || '-' || lower(hex(randomblob(4))),
   'Example Note',
   json_array('tag1', 'tag2', 'tag3')
 );
-```
 
-### Querying JSON Arrays
-
-```sql
 -- Check if array contains a value
 SELECT id, title
 FROM notes
@@ -486,21 +459,14 @@ WHERE EXISTS (
   WHERE json_each.value = 'systems'
 );
 
--- Count array elements
-SELECT id, title, json_array_length(tags) AS tag_count
-FROM notes
-WHERE json_array_length(tags) > 3;
-
 -- Extract unique tags across all notes
 SELECT DISTINCT json_each.value AS tag
 FROM notes, json_each(notes.tags)
 WHERE notes.status = 'active'
 ORDER BY tag;
 
--- Tag cloud (aggregation)
-SELECT
-  json_each.value AS tag,
-  COUNT(*) AS note_count
+-- Tag cloud
+SELECT json_each.value AS tag, COUNT(*) AS note_count
 FROM notes, json_each(notes.tags)
 GROUP BY json_each.value
 ORDER BY note_count DESC;
@@ -509,12 +475,12 @@ ORDER BY note_count DESC;
 ### Updating JSON Arrays
 
 ```sql
--- Add a tag (append to array)
+-- Add a tag
 UPDATE notes
 SET tags = json_insert(tags, '$[#]', 'new-tag')
 WHERE id = 'NOTE-20260208-a3f8c291';
 
--- Remove a tag (requires rebuilding array)
+-- Remove a tag
 UPDATE notes
 SET tags = (
   SELECT json_group_array(value)
@@ -539,32 +505,21 @@ CREATE TABLE notes (
 
 ## CHECK Constraints for Validation
 
-CHECK constraints replace YAML enum and pattern validation.
-
-### Enum-Style Constraints
-
 ```sql
+-- Enum-style
 CREATE TABLE notes (
   id TEXT PRIMARY KEY,
   status TEXT NOT NULL CHECK (status IN ('draft', 'active', 'archived')) DEFAULT 'draft',
   epistemic TEXT CHECK (epistemic IN ('hypothesis', 'tested', 'validated', 'outdated'))
 );
-```
 
-### Range Constraints
-
-```sql
+-- Range
 CREATE TABLE resources (
   id TEXT PRIMARY KEY,
   rating INTEGER CHECK (rating >= 1 AND rating <= 5)
 );
-```
 
-### Pattern Constraints (Regex)
-
-SQLite doesn't have native regex in CHECK constraints, but you can validate formats:
-
-```sql
+-- Pattern (SQLite has no native regex in CHECK)
 CREATE TABLE resources (
   id TEXT PRIMARY KEY,
   url TEXT CHECK (url LIKE 'http%')
@@ -575,21 +530,9 @@ For complex validation, use application-level checks before INSERT.
 
 ## Aggregations
 
-SQLite supports GROUP BY, COUNT, SUM, AVG, MIN, MAX, and more. Memhub cannot do this.
-
-### Basic Aggregations
-
 ```sql
 -- Notes per status
-SELECT status, COUNT(*) AS count
-FROM notes
-GROUP BY status;
-
--- Average rating per resource type
-SELECT resource_type, AVG(rating) AS avg_rating
-FROM resources
-WHERE rating IS NOT NULL
-GROUP BY resource_type;
+SELECT status, COUNT(*) AS count FROM notes GROUP BY status;
 
 -- Monthly note creation counts
 SELECT
@@ -598,16 +541,10 @@ SELECT
 FROM notes
 GROUP BY month
 ORDER BY month DESC;
-```
 
-### Advanced Aggregations
-
-```sql
--- Tag cloud with percentages
+-- Tag cloud with percentages (window function)
 WITH tag_counts AS (
-  SELECT
-    json_each.value AS tag,
-    COUNT(*) AS count
+  SELECT json_each.value AS tag, COUNT(*) AS count
   FROM notes, json_each(notes.tags)
   GROUP BY json_each.value
 )
@@ -622,13 +559,13 @@ LIMIT 20;
 
 ## Building a SQLite-DB Skill
 
-Specialized sqlite-db skills follow a consistent structure. They teach agents how to manage a specific domain using SQLite.
+Specialized sqlite-db skills follow a consistent structure:
 
 ### Directory Layout
 
 ```
 skills/sqlite-<domain>/
-├── SKILL.md                # Skill instructions (when to use, workflows, SQL examples)
+├── SKILL.md                # Instructions, workflows, SQL examples
 ├── assets/
 │   ├── schema.sql          # DDL: tables, indexes, FTS, triggers
 │   └── views.sql           # Reusable views
@@ -641,28 +578,20 @@ skills/sqlite-<domain>/
 
 ### What a SQLite Skill Should Define
 
-1. **Tables** — DDL for all domain entities with constraints, indexes, and foreign keys
-2. **Indexes** — B-tree indexes for common queries, FTS indexes for search
-3. **FTS** — Virtual tables and sync triggers for full-text search
-4. **Views** — Saved queries as first-class database objects
-5. **Triggers** — Auto-timestamps, FTS sync, validation
-6. **Links vocabulary** — Named relationship types (same as memhub: `linksTo`, `derivedFrom`, `partOf`, etc.)
-7. **Database path** — Where the `.db` file lives (e.g., `.sqlite/notes.db`)
-8. **ID prefixes** — Conventions for generating human-readable IDs
-9. **Workflows** — Step-by-step SQL examples for common tasks
+1. **Tables** — DDL with constraints, indexes, and foreign keys
+2. **Indexes** — B-tree indexes for common queries, FTS for search
+3. **Views** — Saved queries as first-class database objects
+4. **Triggers** — Auto-timestamps, FTS sync
+5. **Links vocabulary** — Named relationship types
+6. **Database path** — Where the `.db` file lives
+7. **ID prefixes** — Conventions for human-readable IDs
+8. **Workflows** — Step-by-step SQL examples for common tasks
 
 ### Design Principles
 
-**Schemas encode domain knowledge.** The DDL is the documentation. Use meaningful column names, CHECK constraints, foreign keys, and indexes. The schema should tell you what's important.
-
-**Target database explicitly.** Every `sqlite3` command should specify the full path to the database. Stateless invocation only.
-
-**Views are your menu.** Create views for common queries. Views compose — they can reference other views, use joins, and include aggregations. They're more powerful than memhub's saved queries.
-
-**Use both relationship styles.** Structural foreign keys for ownership (clipping→resource), flexible links table for ad-hoc graph relationships (note→note).
-
-**Include setup scripts.** Provide an idempotent `setup.sh` that creates the database, runs the DDL, and initializes views. Users should be able to initialize a working database with one command.
-
-**Show real workflows.** Don't just list SQL patterns — show the full flow of creating records, linking them, querying, updating, and analyzing over time.
-
-**Be honest about tradeoffs.** SQL is verbose. String escaping is hazardous. But the power (JOINs, FTS, aggregations, window functions) makes it worthwhile for certain domains.
+- **Schemas encode domain knowledge.** DDL is documentation. Use meaningful column names, CHECK constraints, foreign keys, and indexes.
+- **Target database explicitly.** Every `sqlite3` command specifies the full path. Stateless invocation only.
+- **Views are your menu.** Create views for common queries; they compose and can reference other views.
+- **Use both relationship styles.** Foreign keys for ownership, links table for ad-hoc graph relationships.
+- **Include setup scripts.** Provide an idempotent `setup.sh` that initializes a working database with one command.
+- **Always verify destructive operations.** Follow every DELETE and batch UPDATE with a confirming SELECT or COUNT before proceeding.

--- a/plugins/terma/skills/code-review/SKILL.md
+++ b/plugins/terma/skills/code-review/SKILL.md
@@ -1,8 +1,106 @@
 ---
 name: code-review
-description: Review code for quality, correctness, and best practices. Use when the user wants a code review or feedback on their implementation.
+description: Reviews code for quality, correctness, and best practices by identifying bugs, suggesting refactoring opportunities, checking error handling, and reviewing naming conventions and code structure. Use when the user wants a code review, feedback on their implementation, to review a PR or pull request, to check their code, look over a function, or critique changes — e.g. "review my PR", "check my code", "look over this function", "critique my implementation".
 ---
 
 # Code Review
 
 Read and apply the guidance from @../../lib/review.md
+
+## Overview
+
+A thorough code review examines code across several dimensions:
+
+- **Correctness** — logic errors, off-by-one errors, unhandled edge cases, null/undefined handling
+- **Readability** — naming conventions, clarity of intent, comment quality, code organisation
+- **Performance** — inefficient algorithms, unnecessary iterations, memory concerns
+- **Security** — input validation, injection risks, exposed secrets, improper access control
+- **Error handling** — missing try/catch, unhandled promise rejections, silent failures
+
+## Workflow
+
+1. **Read the code** — understand its stated purpose and intended behaviour
+2. **Identify issues** — note bugs, smells, and improvement opportunities as you read
+3. **Categorise by severity** — distinguish blockers (bugs, security issues) from suggestions (style, minor refactors)
+4. **Provide actionable feedback** — for each issue, explain what is wrong, why it matters, and how to fix it
+5. **Verify fixes** — confirm suggested changes address the identified issues without introducing new problems
+
+## Feedback Format
+
+Structure review feedback clearly, for example:
+
+```
+**[Severity: Critical | Major | Minor | Suggestion]** Short title
+
+What: Brief description of the issue.
+Why: Why it matters (impact on correctness, security, performance, etc.).
+Fix: Concrete suggestion or corrected code snippet.
+```
+
+Prioritise critical and major issues at the top. Group related feedback where possible to avoid overwhelming the author.
+
+## Examples
+
+### Example 1 — Critical bug and a Suggestion in the same function
+
+**Code under review:**
+```python
+def get_user(user_id):
+    result = db.query(f"SELECT * FROM users WHERE id = {user_id}")
+    return result[0]
+```
+
+**Review feedback:**
+
+```
+**[Severity: Critical]** SQL injection vulnerability
+
+What: The query is built by directly interpolating `user_id` into the SQL string.
+Why: An attacker can pass a crafted value (e.g. `1 OR 1=1`) to read, modify, or
+     delete arbitrary data in the database.
+Fix: Use a parameterised query:
+     result = db.query("SELECT * FROM users WHERE id = %s", (user_id,))
+```
+
+```
+**[Severity: Suggestion]** No guard against missing user
+
+What: `result[0]` raises an IndexError when no matching user is found.
+Why: Silent crashes are hard to debug and expose an unhelpful error to callers.
+Fix: Return None (or raise a descriptive exception) explicitly:
+     return result[0] if result else None
+```
+
+---
+
+### Example 2 — Major error-handling gap
+
+**Code under review:**
+```javascript
+async function fetchConfig(url) {
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
+}
+```
+
+**Review feedback:**
+
+```
+**[Severity: Major]** Unhandled network and HTTP errors
+
+What: Neither fetch failures (network down) nor non-2xx HTTP responses are caught.
+Why: A failed fetch rejects the promise and crashes the caller; a 404 or 500
+     silently returns an error body that callers treat as valid config.
+Fix: Check response.ok and wrap in try/catch:
+
+     async function fetchConfig(url) {
+       try {
+         const response = await fetch(url);
+         if (!response.ok) throw new Error(`HTTP ${response.status}`);
+         return await response.json();
+       } catch (err) {
+         throw new Error(`Failed to fetch config: ${err.message}`);
+       }
+     }
+```

--- a/plugins/terma/skills/ideate/SKILL.md
+++ b/plugins/terma/skills/ideate/SKILL.md
@@ -1,12 +1,44 @@
 ---
 name: ideate
-description: Brainstorm and explore ideas for a project or feature. Use when the user wants to generate creative solutions or explore possibilities.
+description: Brainstorm and explore ideas by generating alternative approaches, structured idea frameworks, and creative possibilities for a project or feature. Use when the user wants to ideate, think through options, spitball ideas, explore alternatives, or ask "what if" — e.g., "brainstorm features", "what are my choices here", "help me think through this", or "give me some alternatives".
 ---
 
 # Ideate
 
 I'm trying to brainstorm: $ARGUMENTS
 
-Use a subagent or Task() to explore the deck of ideas below and apply them to our current project.
+## Workflow
 
-Read and apply the guidance from @../../lib/ideate.md
+1. **Understand the context** — Identify the problem space, constraints, and goals from `$ARGUMENTS` and the current project.
+2. **Explore the idea deck** — Use a subagent or Task() to read and apply the guidance from @../../lib/ideate.md, which contains the full deck of ideation techniques and frameworks.
+3. **Generate ideas** — Apply relevant techniques from the deck to produce a diverse set of ideas. Aim for breadth before depth.
+4. **Present results** — Organise ideas into a clear, scannable output (e.g., grouped themes, ranked options, or a pros/cons breakdown) so the user can evaluate and act on them.
+
+## Core Techniques (inline summary)
+
+These three techniques are a good starting point before consulting the full deck:
+
+- **Reverse assumptions** — List 5 assumptions baked into the current design, then write the opposite of each to find non-obvious directions. Ask: *"What if we removed this constraint entirely — what would that unlock?"* (e.g., "What if the user never has to log in?").
+- **Combine or remix** — List existing features or concepts, then ask: *"What new value is created if I merge X with Y?"* (e.g., "Merge the search flow with the onboarding wizard — what does that experience look like?").
+- **Solve adjacent problems** — Step one stage before and after the stated problem and ask: *"What struggle exists just outside the stated scope?"* (e.g., for a notification feature: "How do users *dismiss* or *action* those notifications — can we design for that too?").
+
+Detailed technique guidance and the full idea deck are in @../../lib/ideate.md — read and apply that file for the complete set of frameworks.
+
+## Example Output
+
+Below is what a typical brainstorm result looks like for "add a notification feature":
+
+**Theme A — Delivery mechanisms**
+- In-app banner (low friction, easily dismissed)
+- Email digest (async, suits low-urgency updates)
+- Push notification (high attention, risk of fatigue)
+
+**Theme B — User control**
+- Per-channel mute/snooze controls
+- Quiet-hours scheduling
+- Preference centre accessible from every notification
+
+**Theme C — Adjacent opportunity**
+- "Action from notification" — let users resolve the triggering event without leaving the notification (e.g., approve a request inline)
+
+*Ranked top pick:* In-app banner + inline action, because it minimises context switching while keeping interruption low.

--- a/plugins/terma/skills/implement/SKILL.md
+++ b/plugins/terma/skills/implement/SKILL.md
@@ -1,8 +1,44 @@
 ---
 name: implement
-description: Implement a plan or feature. Use when the user has a defined plan ready to be coded.
+description: Executes multi-step implementation plans by writing code across files and modules, running tests, and verifying changes. Use when the user has a defined technical plan, spec, architecture doc, or step-by-step instructions ready to be coded — e.g. "execute the plan", "start building", "implement the spec", "code this up", "follow the implementation steps", "start coding", or "build this out".
 ---
 
 # Implement Plan
 
 Read and apply the guidance from @../../lib/implement.md
+
+## General Implementation Workflow
+
+1. **Read the plan** — Fully understand the spec, steps, or instructions before writing any code.
+2. **Identify affected files and modules** — Determine which files need to be created or modified.
+3. **Implement step by step** — Follow the plan sequentially, completing each step before moving to the next.
+4. **Run tests** — After implementation, run the relevant test suite to verify correctness (e.g. `npm test`, `pytest`, `cargo test`, `go test ./...`).
+   - If tests fail: analyse the failure → fix the code → re-run tests → only proceed when passing (or explicitly flag unresolvable failures).
+5. **Check for breaking changes** — Review diffs (`git diff`) for unintended side effects or regressions.
+6. **Summarise what was done** — Provide a brief report of changes made, files touched, and any deviations from the original plan.
+
+## Example Workflow
+
+Given a plan file `PLAN.md`:
+```
+## Steps
+1. Add a `formatDate(date: Date): string` utility in `src/utils/date.ts`
+2. Import and use it in `src/components/EventCard.tsx`
+3. Add unit tests in `tests/utils/date.test.ts`
+```
+
+The agent would:
+1. Read `PLAN.md` in full before touching any files.
+2. Create `src/utils/date.ts` with the `formatDate` implementation.
+3. Update `src/components/EventCard.tsx` to import and call `formatDate`.
+4. Write tests in `tests/utils/date.test.ts`, then run `npm test` to confirm they pass.
+5. Run `git diff` to check no unintended files were modified.
+6. Report: "Added `formatDate` utility, updated `EventCard`, all tests passing. No deviations from plan."
+
+## Validation Checklist
+
+- [ ] All steps in the plan have been addressed
+- [ ] New or modified code follows existing conventions and style
+- [ ] Tests pass (or failures are explained and flagged)
+- [ ] No unintended files were modified
+- [ ] Any ambiguities in the plan were surfaced and resolved before or during implementation

--- a/plugins/terma/skills/orient/SKILL.md
+++ b/plugins/terma/skills/orient/SKILL.md
@@ -1,12 +1,58 @@
 ---
 name: orient
-description: Explore and understand a project's structure and functionality. Use when starting work on a new or unfamiliar codebase.
+description: Explore and understand a new or unfamiliar codebase by mapping its directory structure, identifying entry points, analyzing dependencies, and locating key configuration files. Use when onboarding to a new repo, getting started with an unfamiliar project, or asked to understand this codebase — including code exploration, repository orientation, and navigating project architecture.
 ---
 
 Read and apply the guidance from @../../lib/subagent.md
 
 # Orient
 
-Read the `README.md` and the core files mentioned below, fan out from there to explore the project's structure and functionality.
+Read `README.md` first, then systematically explore the project's structure and functionality using the steps below. Write a report to brief the lead project agent so we can get to work.
 
-Write a report on to brief the lead project agent so we can get to work!
+## Exploration Steps
+
+Work through these in order, fanning out as needed based on what you find:
+
+1. **README & docs** — Read `README.md`. Check for a `docs/` directory, `CONTRIBUTING.md`, `CHANGELOG.md`, or `ARCHITECTURE.md`.
+2. **Package & dependency manifests** — Look for `package.json`, `pyproject.toml`, `requirements.txt`, `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, or equivalent. Note the tech stack and key dependencies.
+3. **Build & task configuration** — Check for `Makefile`, `Taskfile`, `justfile`, `.github/workflows/`, `Dockerfile`, `docker-compose.yml`, and similar. Note how the project is built, tested, and deployed.
+4. **Directory layout** — Survey top-level directories (`src/`, `lib/`, `app/`, `tests/`, `scripts/`, etc.) to understand the overall layout.
+5. **Entry points** — Identify the main entry point(s): `main.*`, `index.*`, `app.*`, `server.*`, or whatever the manifest points to.
+6. **Core modules** — Briefly read the most central source files to understand dominant patterns (framework choice, data models, API surface, etc.).
+7. **Configuration** — Note environment config (`.env.example`, `config/`, settings files) and any secrets management.
+8. **Tests** — Glance at the test directory to understand the testing approach and coverage posture.
+
+## Report Template
+
+Produce a structured report covering:
+
+```
+## Project: <name>
+
+### Overview
+One-paragraph summary of what the project does and who it is for.
+
+### Tech Stack
+- Language(s): ...
+- Frameworks / libraries: ...
+- Databases / external services: ...
+- Build / task tooling: ...
+
+### Repository Layout
+Brief description of top-level directories and their purpose.
+
+### Entry Points
+List the main entry point(s) and how to run the project locally.
+
+### Key Dependencies
+Highlight the most important or unusual dependencies.
+
+### Architecture Patterns
+Describe dominant patterns (e.g. MVC, event-driven, microservices, monorepo, etc.).
+
+### Testing Approach
+Test framework, location of tests, and rough coverage posture.
+
+### Open Questions / Gaps
+Anything unclear, missing, or that needs follow-up before starting work.
+```

--- a/plugins/terma/skills/plan/SKILL.md
+++ b/plugins/terma/skills/plan/SKILL.md
@@ -1,6 +1,52 @@
 ---
 name: plan
-description: Create a structured plan for implementing a feature or solving a problem. Use when the user needs to plan before coding.
+description: Creates a structured implementation plan by breaking down tasks, identifying dependencies, estimating complexity, and defining milestones for a feature or problem. Use when the user wants to plan, design an approach, build a roadmap, define a strategy, outline implementation steps, or asks "how should I build this?" before writing code.
+---
+
+## Overview
+
+This skill produces a structured plan that organises work into clear phases, tasks, and dependencies before any code is written.
+
+## What $ARGUMENTS Does
+
+Pass any relevant context as `$ARGUMENTS` — such as the feature description, constraints, tech stack, or scope. If no arguments are given, the skill will prompt for the necessary details.
+
+## Workflow
+
+1. **Gather requirements** — Understand the goal, constraints, and context from `$ARGUMENTS` or by asking clarifying questions. Ask: *What is the desired outcome? What are the constraints (time, tech stack, scope)?*
+2. **Analyse the problem** — Identify the key components, unknowns, risks, and dependencies involved. Ask: *What must exist before each part can start? What could block progress?* For example: an authentication system must exist before implementing user profiles; a database schema must be finalised before writing data-access logic.
+3. **Structure the plan** — Break the work down into phases and tasks with a logical sequence. Ask: *Can this be parallelised? What is the smallest testable increment?*
+4. **Validate with the user** — Present the plan and invite feedback before proceeding to implementation. Ask: *Does this order make sense? Are there missing pieces or constraints I haven't accounted for?*
+
+### Complexity Estimation Heuristics
+
+When labelling tasks `low / medium / high`:
+
+- **Low** — Well-understood, self-contained change with no external dependencies (e.g., adding a config flag, updating a UI label).
+- **Medium** — Touches multiple components or requires coordination across layers, but the approach is clear (e.g., adding a new API endpoint with validation and tests).
+- **High** — Significant unknowns, cross-cutting concerns, or architectural decisions involved (e.g., migrating an auth system, introducing a new data store).
+
+## Example Output Format
+
+```
+## Plan: <Feature or Problem Title>
+
+### Phase 1: <Phase Name>
+- [ ] Task A — <brief description> (complexity: low/medium/high)
+- [ ] Task B — depends on Task A
+
+### Phase 2: <Phase Name>
+- [ ] Task C
+- [ ] Task D — depends on Task C
+
+### Dependencies
+- Task B requires Task A to be complete
+- Phase 2 assumes Phase 1 is fully tested
+
+### Open Questions / Risks
+- <Any unknowns that need resolution before or during implementation>
+```
+
 ---
 
 Read and apply the guidance from @../../lib/plan.md

--- a/plugins/terma/skills/skill-improver/SKILL.md
+++ b/plugins/terma/skills/skill-improver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-improver
-description: This skill should be used at natural checkpoints (after completing complex tasks, at session end, or when friction occurs) to reflect on skill and process execution and identify targeted improvements. Use when experiencing confusion, repeated failures, or discovering new patterns that should be codified into skills for smoother future operation.
+description: This skill guides structured reflection on skills and processes to identify targeted improvements, update skill files, create new skills from recurring patterns, and log friction points. Use when experiencing confusion, repeated failures, or discovering new patterns that should be codified; at natural checkpoints such as session end or after completing a complex task; or when the user asks "what went wrong", "how can we do this better", "retrospective", or "lessons learned".
 ---
 
 # Skill Improver
@@ -9,22 +9,14 @@ description: This skill should be used at natural checkpoints (after completing 
 
 This skill guides reflective improvement of skills and processes through structured analysis. Rather than automatically suggesting changes, it provides a framework for mindful reflection to identify high-impact improvements without creating bloat.
 
-The philosophy follows Buddhist "skillful means" (upaya) - developing concrete, practical wisdom through iteration. The goal is harmonious operation between Claude and the user by refining skills to be clearer, more complete, and more efficient.
+The goal is to refine skills to be clearer, more complete, and more efficient.
 
 ## When to Use This Skill
 
-**Use this skill:**
-- At the end of a session when significant work has been completed
 - After completing a complex task that involved multiple skills or tools
 - When experiencing repeated friction, confusion, or failures during execution
 - When discovering a workaround or novel pattern that should be captured
-- When the user expresses frustration with a process or skill
 - After successfully navigating a challenging workflow that could be easier next time
-
-**Do not use this skill:**
-- After every tiny task (reflection should be purposeful, not reflexive)
-- When there's nothing substantial to improve
-- During active work (finish first, then reflect)
 
 ## Reflection Workflow
 
@@ -38,7 +30,7 @@ Clearly establish what process or skill is being reflected upon:
 
 ### 2. Apply the Reflection Framework
 
-Use `references/reflection_framework.md` to systematically analyze the experience. The framework provides structured questions across five dimensions:
+Read `references/reflection_framework.md` and work through the questions across five dimensions:
 
 1. **Process Execution** - What happened? What worked? What didn't?
 2. **Skill Content Analysis** - Was the skill clear, complete, efficient, accurate?
@@ -46,65 +38,55 @@ Use `references/reflection_framework.md` to systematically analyze the experienc
 4. **Pattern Recognition** - Is this a one-time issue or recurring pattern?
 5. **Improvement Identification** - What specific changes would help?
 
-Load and review the framework:
-
-```
-Read references/reflection_framework.md and work through the relevant questions
-```
+Focus your extraction on these key questions:
+- Where did execution slow down, stall, or require backtracking? Note the specific step.
+- What information was missing that had to be discovered at runtime? Name the gap.
+- Was anything repeated that a script or template could have handled? Identify the repetition.
+- Would this problem recur, or was it a one-time environment issue? Classify accordingly.
 
 ### 3. Identify Improvement Patterns
 
-Consult `references/improvement_patterns.md` to recognize common issues:
-- Clarity issues (ambiguous descriptions, jargon, vague steps)
-- Completeness issues (missing prerequisites, edge cases, error handling)
-- Efficiency issues (redundant instructions, missing scripts, context bloat)
-- Usability issues (poor discoverability, overwhelming complexity)
-- Structural issues (wrong abstraction level, missing decision trees)
+Read `references/improvement_patterns.md` and match each observed issue to one or more of these categories:
 
-Load and cross-reference patterns:
+| Pattern | Signals |
+|---|---|
+| Clarity | Ambiguous descriptions, jargon, vague steps |
+| Completeness | Missing prerequisites, edge cases, error handling |
+| Efficiency | Redundant instructions, missing scripts, context bloat |
+| Usability | Poor discoverability, overwhelming complexity |
+| Structural | Wrong abstraction level, missing decision trees |
 
-```
-Read references/improvement_patterns.md to identify which patterns match the observed issues
-```
+Record which pattern(s) apply — this feeds directly into step 4.
 
 ### 4. Formulate Specific Improvements
 
-Based on reflection, create concrete, actionable improvement proposals. Each improvement should include:
+For each matched pattern, write a concrete improvement proposal:
 
 - **Skill/Process**: Name of what's being improved
 - **Issue Observed**: Concrete description of the problem
 - **Root Cause**: Why this happened (what's missing or wrong)
 - **Proposed Change**: Specific, actionable improvement
 - **Impact**: High/Medium/Low priority
-- **Implementation**: Exact files and changes needed
+- **Implementation**: Exact files and changes needed (e.g., `skills/pdf-editor/scripts/rotate_pdf.py`, add section "Error Handling" to `skills/pdf-editor/skill.md`)
 
 ### 5. Apply Improvement Principles
 
-Before finalizing recommendations, verify they follow skillful means:
-
-**Do:**
-- Be specific and concrete
-- Show evidence from actual experience
-- Consider cost/benefit ratio
-- Prefer simplification over addition
-- Document principles and "why", not just "what"
-
-**Don't:**
-- Pile on multiple vague changes
-- Over-engineer solutions
-- Duplicate existing information
-- Spam the user with minor tweaks
+Before finalizing recommendations, verify each proposed change:
+- Has a specific root cause grounded in observed experience
+- Simplifies rather than layers on complexity
+- Documents principles and "why", not just "what"
+- Passes a cost/benefit check — avoid changes that won't actually be used
 
 ### 6. Execute Improvements (if appropriate)
 
-For high-impact improvements:
-- If editing an existing skill, use the skill-creator skill to make changes
-- If creating a new skill is warranted, use the skill-creator skill
-- For process improvements, document the new approach
+For **high-impact improvements**:
+- Invoke the `skill-creator` skill to edit an existing skill or create a new one
+- Example invocation: *"Use skill-creator to add a `scripts/rotate_pdf.py` to the `pdf-editor` skill with permission error handling"*
+- For process improvements without a dedicated skill, document the new approach in the relevant `references/` file
 
-For lower-impact improvements:
-- Present findings to the user for future consideration
-- Ask if they'd like to implement changes now or later
+For **lower-impact improvements**:
+- Present findings to the user with the structured proposal from step 4
+- Ask: *"Would you like to implement these changes now, or log them for later?"*
 
 ## Decision Tree: Improve vs Create
 
@@ -130,8 +112,6 @@ Sometimes the best improvement is creating a new skill. Use this decision tree:
 
 ## Resources
 
-This skill includes reference documentation to guide the reflection process:
-
 ### references/reflection_framework.md
 
 Structured framework with questions across five dimensions:
@@ -141,7 +121,7 @@ Structured framework with questions across five dimensions:
 4. Pattern Recognition
 5. Improvement Identification
 
-Use this to systematically analyze what happened and identify specific improvement opportunities.
+**Extract**: For each dimension, note the specific friction point and its location in the workflow.
 
 ### references/improvement_patterns.md
 
@@ -152,7 +132,7 @@ Catalog of common skill issues and their solutions:
 - Usability issues (discoverability, complexity, inconsistent terminology)
 - Structural issues (abstraction level, decision trees, undocumented scripts)
 
-Use this to recognize patterns and find proven solutions.
+**Extract**: The matched pattern name and its recommended solution type (e.g., "add script", "split skill", "add troubleshooting section").
 
 ## Example Usage
 
@@ -161,51 +141,25 @@ Use this to recognize patterns and find proven solutions.
 **Scenario**: After using the `pdf-editor` skill to rotate several PDFs, Claude had to rewrite rotation code multiple times due to varying file permissions.
 
 **Reflection**:
-1. **Context**: Used pdf-editor skill to rotate PDFs, encountered permission issues
-2. **Framework application**: Process execution had friction - repetitive code writing, unexpected errors
-3. **Pattern recognition**: Matches "Missing scripts for repetitive tasks" and "Incomplete error handling"
-4. **Improvement formulation**:
-   - **Skill/Process**: pdf-editor
-   - **Issue**: Rewrote PyPDF2 rotation code 3 times; permission errors not handled
-   - **Root Cause**: No rotation script; permission handling undocumented
-   - **Proposed Change**: Create `scripts/rotate_pdf.py` with permission handling; add troubleshooting section
-   - **Impact**: High - eliminates code rewriting, prevents permission errors
-   - **Implementation**: Create script, update SKILL.md to reference it
-5. **Execution**: Use skill-creator to add script and update documentation
+- **Issue**: Rewrote PyPDF2 rotation code 3 times; permission errors not handled
+- **Pattern**: "Missing scripts for repetitive tasks" + "Incomplete error handling"
+- **Root Cause**: No rotation script; permission handling undocumented
+- **Proposed Change**: Create `skills/pdf-editor/scripts/rotate_pdf.py` with permission handling; add "Troubleshooting" section to `skills/pdf-editor/skill.md`
+- **Impact**: High — eliminates rewriting, prevents permission errors
+- **Execution**: *"Use skill-creator to add `scripts/rotate_pdf.py` to the `pdf-editor` skill. The script should accept a file path and rotation angle, handle `PermissionError` with a clear message, and use PyPDF2."*
 
 ### Example 2: Missing Reference Documentation
 
-**Scenario**: After creating a Lorn/Clams Casino inspired beat using the `strudel` skill, user feedback revealed bass tone missed the mark. User corrected: "don't need to encode every iteration" and "bass tone not reminding me of references."
+**Scenario**: After creating a Lorn/Clams Casino inspired beat using the `strudel` skill, user feedback revealed bass tone missed the mark and URL encoding was being done too frequently.
 
-**Reflection**:
-1. **Context**: Used strudel skill for dark ambient hip-hop, encountered two issues
-2. **Framework application**:
-   - Process execution: URL encoding was inefficient during iterations
-   - Skill content: No guidance for translating artist references into techniques
-3. **Pattern recognition**: Matches "Vague workflow steps" and "Missing reference documentation"
-4. **Improvement formulation**:
-   - **Skill/Process**: strudel
-   - **Issue #1**: Encoded URL after every iteration; user said only needed on initial creation
-   - **Root Cause**: Skill said "Always encode after modifications" - too broad
-   - **Proposed Change**: Clarify when to encode (initial only, skip iterations, final if requested)
-   - **Impact**: Medium - prevents unnecessary work
-   - **Implementation**: Update SKILL.md section "Providing Output to the User"
+**Issue #1**: Encoded URL after every iteration; user said only needed on initial creation
+- **Root Cause**: Skill said "Always encode after modifications" — too broad
+- **Proposed Change**: In `skills/strudel/skill.md`, replace "Always encode after modifications" with "Encode on initial creation and on final export only; skip during iterative editing"
+- **Impact**: Medium
 
-   - **Issue #2**: No systematic guide for artist characteristics (Lorn, Clams Casino)
-   - **Root Cause**: No reference for common genre/artist styles
-   - **Proposed Change**: Create `references/genre-styles.md` with artist characteristics and Strudel techniques
-   - **Impact**: High - translates user references into concrete implementation
-   - **Implementation**: Create reference file, update SKILL.md to reference it
-5. **Execution**: Used skill-creator to implement both improvements; user approved both
+**Issue #2**: No guide for translating artist references (Lorn, Clams Casino) into Strudel techniques
+- **Root Cause**: No reference for common genre/artist styles
+- **Proposed Change**: Create `skills/strudel/references/genre-styles.md` mapping artist characteristics to Strudel functions and patterns
+- **Impact**: High
 
-## Philosophy: Skillful Means
-
-The goal is harmonious operation through continuous refinement:
-
-- **Concrete over abstract**: Prefer working examples to theoretical descriptions
-- **Simplicity over completeness**: Handle 80% of cases well rather than 100% poorly
-- **Clarity over cleverness**: Straightforward instructions beat elegant complexity
-- **Practical over perfect**: Ship useful improvements, iterate continuously
-- **Harmonious over comprehensive**: Reduce friction, don't add features
-
-Each improvement should make Claude's and the user's life tangibly easier. If it doesn't pass this test, don't recommend it.
+**Execution**: *"Use skill-creator to (1) update the encoding instruction in the strudel skill and (2) create `references/genre-styles.md` with sections for Lorn and Clams Casino."* User approved both changes.

--- a/plugins/terma/skills/skill-networks/SKILL.md
+++ b/plugins/terma/skills/skill-networks/SKILL.md
@@ -1,12 +1,93 @@
-When designing a skill, I first think of how it will be used. Skills are tightly focused, all signal, no noise, packages of mental models. They are the principle distilled with some specifics woven in.
+---
+name: skill-design
+description: Guides the agent in designing, writing, and composing SKILL.md files as tightly focused packets of wisdom — including structuring frontmatter YAML, writing description fields, organising skill sections, and validating conciseness. Covers all abstraction levels—specific knowledge, practices, mental models, techniques, principles, and abstract processes—and emphasises composability with other skills. Use when creating a new skill, refining an existing skill, thinking about how skills compose together, or structuring condensed mental-model cards for an agent skill library.
+---
 
-Skills must not be bloated, since they are designed to compose with other skills dynamically. Similar to a knowledge graph or zettelkasten notebook, skills are index cards of functionality. They are written to be maximally effective and salient. Skills occur at many levels of abstraction:
+When designing a skill, think first about how it will be used. Skills are tightly focused, all-signal packages of distilled wisdom — index cards of functionality written to be maximally effective and composable, not encyclopaedias. Skills occur at many levels of abstraction:
 
-- specific knowledge "Testing with Deno"
-- specific practice "SWOT Analysis", "Technical Review"
-- mental models "Multi-scale Thinking", "Pace Layers"
-- techniques "Invert Foreground and Background", "Enabling Constraints", "Spread of Three Ideas", oblique strategies
-- principles "Domain Driven Design", "Design for Emergence"
-- abstract processes "Taking an Idea from Concept to Implementable", "Understanding what's truly motivating about an idea", "Bisecting Possibility Space", "Contrasting Multiple Models", "Representing Abstract Systems using Category Theory"
+- **specific knowledge** — "Testing with Deno"
+- **specific practice** — "SWOT Analysis", "Technical Review"
+- **mental models** — "Multi-scale Thinking", "Pace Layers"
+- **techniques** — "Invert Foreground and Background", "Enabling Constraints", "Spread of Three Ideas", oblique strategies
+- **principles** — "Domain Driven Design", "Design for Emergence"
+- **abstract processes** — "Taking an Idea from Concept to Implementable", "Understanding what's truly motivating about an idea", "Bisecting Possibility Space", "Contrasting Multiple Models", "Representing Abstract Systems using Category Theory"
 
-But all skills should be aware that other skills may want to compose with them and encourage the agent to consider certain kinds of skills in concert with the specific skill. Skills are condensed packets of WISDOM not just information.
+All skills should be aware that other skills may want to compose with them and encourage the agent to consider certain kinds of skills in concert with the specific skill.
+
+---
+
+## Skill Creation Workflow
+
+1. **Identify abstraction level** — Decide which of the six levels above best fits the skill. This determines the appropriate tone (concrete steps vs. conceptual framing) and density.
+2. **Name and describe** — Write the `name` (lowercase, hyphenated) and `description` (third-person, includes a "Use when…" clause with natural trigger terms). The description is the primary routing signal; make it precise.
+3. **Draft core content** — Write the skill body as a focused packet: the key principle, model, or process. Avoid padding. Every sentence should earn its place.
+4. **Add composition hints** — Explicitly note which other skill types or domains pair well with this skill, so the agent knows when to reach for complementary skills.
+5. **Validate conciseness** — Apply the bloat checklist below before finalising.
+
+---
+
+## Frontmatter Template
+
+```yaml
+---
+name: your-skill-name
+description: One-to-two sentence description in third-person that names what the skill does and includes a "Use when..." clause with natural trigger phrases.
+---
+```
+
+Optional fields (`tags`, `allowed-tools`, `version`, etc.) should only be added when they provide genuine routing or execution value.
+
+---
+
+## Bloat Checklist
+
+A skill is **appropriately concise** when:
+- [ ] Every paragraph contains a distinct, actionable or conceptual point
+- [ ] No sentence merely restates the title or description
+- [ ] Examples illustrate; they do not repeat the principle in different words
+- [ ] The body can be read in under 60 seconds
+- [ ] Composition hints are present but brief (one sentence or a short list)
+
+A skill is **too bloated** when:
+- It contains background context the agent already has from general training
+- It hedges the same point more than once
+- It includes step-by-step instructions that belong in a separate, more specific skill
+- Its body exceeds roughly 400–500 tokens for a conceptual skill, or ~800 tokens for a procedural one
+
+---
+
+## Worked Examples
+
+### Specific Knowledge skill (tight, factual)
+```
+---
+name: deno-testing
+description: Covers writing and running tests in Deno using the built-in test runner. Use when writing Deno tests, debugging test failures, or setting up a Deno test suite.
+---
+
+Use `Deno.test("name", () => { ... })` as the unit of test. Run with `deno test`. Use `--filter` to run a subset. Assertions live in `https://deno.land/std/assert/mod.ts`. Group related tests with a shared prefix in the name string. For async tests return a Promise or use async/await directly inside the callback.
+```
+
+### Mental Model skill (conceptual, composable)
+```
+---
+name: pace-layers
+description: Applies Stewart Brand's Pace Layers model to reason about change at different timescales within a system. Use when analysing why parts of a system resist change, prioritising interventions, or understanding systemic inertia.
+---
+
+Systems are composed of layers that change at vastly different speeds: fashion/art → commerce → infrastructure → governance → culture → nature (fastest to slowest). Faster layers innovate; slower layers provide stability and absorb shocks. Interventions aimed at a slow layer using fast-layer tools usually fail. When diagnosing friction or planning change, identify which layer you are operating in and what constraints the layers below impose.
+
+Composes well with: Multi-scale Thinking, Domain Driven Design, Design for Emergence.
+```
+
+### Abstract Process skill (procedural, open-ended)
+```
+---
+name: bisect-possibility-space
+description: A technique for narrowing a large solution space by repeatedly halving it with targeted questions or experiments. Use when facing an overwhelming number of options, debugging an unknown root cause, or exploring a new domain efficiently.
+---
+
+State the full possibility space explicitly. Identify a question whose answer eliminates roughly half. Commit to the answer (don't hedge), then repeat on the remaining half. Stop when the remaining space is small enough to evaluate directly. The key discipline is committing to binary splits rather than exploring branches in parallel, which preserves cognitive focus and produces a traceable decision path.
+
+Composes well with: Contrasting Multiple Models, Technical Review.
+```

--- a/plugins/terma/skills/taking-an-idea-to-implementable-prototype/SKILL.md
+++ b/plugins/terma/skills/taking-an-idea-to-implementable-prototype/SKILL.md
@@ -1,20 +1,181 @@
+---
+name: idea-to-prototype
+description: Takes a raw idea through a structured, interactive multi-agent process to produce an implementable prototype plan. Use when a user wants to explore, develop, or validate a new idea — capturing a concept brief, generating pitch summaries, producing design sketches, writing a scoped technical specification, compiling research briefs on prior art, and outputting a phased project timeline — to decide if something is worth building or to fail fast. Ideal for brainstorming sessions, product ideation, prototype scoping, and turning vague concepts into actionable plans. Distinct from general project planning by its end-to-end ideation-to-prototype workflow with explicit kill criteria at each phase.
+---
+
 # Taking an idea to implementable prototype
 
-Use a team of agents to support this process. The goal is to go from an idea to something worth building, or fail along the way. This is meant to be an interactive, creative discussion. Document the key artifacts and decisions along the way.
+Use a team of agents to support this process. The goal is to go from a raw idea to something worth building — or to fail fast along the way. This is an interactive, creative discussion; document key artifacts and decisions at each phase.
 
-1. capture concept (imagine, diverge, capture inspiration)
-    - let's hold the idea gently and entertain a superposition of what it could be
-2. produce pitch (converge, find compelling angle, creative q&a)
-    - why should anyone be excited about this? why bother building it, we have lots of ideas to try, why this one?
-    - maybe there just isn't a compelling angle and it dies here? that's ok too
-3. design (how does it work? diverge in into deeper details)
-    - think Christopher Alexander, Brett Victor
-4. spec (how can we see if it is worth doing? converge into a plan that can be built)
-    - for a prototype, it's important to build as fast as possible to get the maximum possible taste of what would define a good outcome
-    - conversely, to fails as fast as possible by invalidating the entire concept
-    - this is a prerequisite to building a full-scale solution
-5. research whether spec is actually possible, find resources and prior art to speed up process
-    - find the best possible examples to draw from, it's worth checking if someone has already found an answer
-6. construct a project plan with phases, steps, tasks and validation gates at key stages
-    - pre-empt as many issues as possible to prevent wasting time during grunt work of implementation
-    
+## Agent Roles
+
+Assign specialised agents to drive each phase:
+
+- **Concept Agent** — Phase 1: captures and expands the raw idea
+- **Pitch Agent** — Phase 2: stress-tests value proposition and audience fit
+- **Design Agent** — Phase 3: explores mechanics and user flows
+- **Spec Agent** — Phase 4: scopes the minimal buildable prototype
+- **Research Agent** — Phase 5: finds prior art and reusable components
+- **Planning Agent** — Phase 6: structures the build into phases and gates
+
+Agents may hand off sequentially or work in parallel where phases overlap (e.g., Research can run alongside Design).
+
+---
+
+## Phase 1 — Capture Concept
+*Diverge: imagine, collect inspiration, hold multiple possibilities*
+
+**Goal:** Articulate the idea in its fullest, most open form before converging.
+
+**Actions:**
+- Prompt the user with open questions: *What problem does this solve? Who feels this pain? What's the dream outcome?*
+- Generate 3–5 variations on the core concept to explore the space
+- Record all angles without filtering
+
+**Artifact — Concept Brief:**
+```
+Idea: <one-line summary>
+Problem space: <what pain or opportunity exists>
+Possible forms: <2–5 variations on how this could manifest>
+Inspiration / analogues: <anything similar, even loosely>
+Open questions: <what we don't know yet>
+```
+
+**Gate:** A Concept Brief exists with at least one clearly articulated problem space. If the idea cannot be stated as a problem or opportunity, loop back.
+
+---
+
+## Phase 2 — Produce Pitch
+*Converge: find the compelling angle, run creative Q&A*
+
+**Goal:** Determine whether this idea is worth pursuing over other ideas competing for time and attention.
+
+**Actions:**
+- Answer three forcing questions: *Who specifically benefits? Why does this matter now? What makes this distinct?*
+- Identify the single most compelling angle
+- Actively attempt to kill the idea — if no strong counter-argument emerges, proceed
+
+**Artifact — Pitch Summary:**
+```
+One-liner: <idea in one sentence>
+Audience: <who benefits and why they care>
+Why now: <timing, context, or urgency>
+Unique angle: <what makes this different>
+Biggest risk: <the most likely reason this fails>
+Verdict: PROCEED / KILL / REVISIT
+```
+
+**Gate:** Pitch answers all three forcing questions with specifics. A "KILL" verdict here is a valid, valuable outcome — not a failure.
+
+---
+
+## Phase 3 — Design
+*Diverge: explore how it works in deeper detail*
+
+**Goal:** Understand the internal mechanics, user flows, and key decisions before committing to a scope.
+
+**Actions:**
+- Map the core user journey (entry → key action → outcome)
+- Identify the 2–3 central design decisions that most affect the outcome
+- Explore edge cases and interaction patterns; reference prior art where useful (e.g., patterns from Christopher Alexander, Brett Victor's explorable explanations)
+
+**Artifact — Design Sketch:**
+```
+Core user journey:
+  1. User starts at: <entry point>
+  2. Key action: <what the user does>
+  3. Outcome: <what changes for them>
+
+Central design decisions:
+  - Decision A: <option 1> vs <option 2> — leaning toward: <choice + rationale>
+  - Decision B: ...
+
+Key unknowns / risks: <what could invalidate this design>
+```
+
+**Gate:** Core user journey is legible and at least two design decisions are documented. If no coherent journey exists, return to Phase 1 or 2.
+
+---
+
+## Phase 4 — Spec
+*Converge: define the minimal buildable prototype*
+
+**Goal:** Scope a prototype that delivers the maximum signal about viability in the minimum build time — either confirming the concept or invalidating it quickly.
+
+**Actions:**
+- Strip the design to its essential hypothesis-testing core
+- List what is explicitly OUT of scope for the prototype
+- Define what a "good outcome" looks like (success signal) and what would confirm the concept is wrong (kill signal)
+
+**Artifact — Prototype Spec:**
+```
+Prototype hypothesis: <the one thing this build will prove or disprove>
+In scope:
+  - <feature / behaviour 1>
+  - <feature / behaviour 2>
+Out of scope (deferred):
+  - <anything that can wait>
+Success signal: <observable result that confirms the concept>
+Kill signal: <observable result that invalidates the concept>
+Estimated build effort: <rough order of magnitude — hours / days / weeks>
+```
+
+**Gate:** Hypothesis is stated as a falsifiable claim. Both success and kill signals are concrete and observable. If spec cannot be scoped to a prototype, escalate to stakeholders before proceeding.
+
+---
+
+## Phase 5 — Research
+*Find prior art, resources, and faster paths*
+
+**Goal:** Avoid reinventing the wheel; find the best existing examples to draw from or build on.
+
+**Actions:**
+- Search for existing implementations, papers, open-source projects, or tools that overlap with the spec
+- Identify the closest analogues and what can be reused or adapted
+- Flag any findings that materially change the spec or design
+
+**Artifact — Research Brief:**
+```
+Prior art found:
+  - <source>: <what it does> — relevance: <how it applies>
+  - ...
+Reusable components / libraries / patterns: <list>
+Gaps not addressed by prior art: <what must be built from scratch>
+Spec changes triggered by research: <any updates to Phase 4 spec>
+```
+
+**Gate:** At least one search pass completed. If a prior solution fully solves the problem, surface it before proceeding to build.
+
+---
+
+## Phase 6 — Project Plan
+*Construct a phased plan with validation gates*
+
+**Goal:** Translate the spec into an ordered, executable build plan that pre-empts common blockers.
+
+**Actions:**
+- Break the prototype into phases (e.g., scaffold → core loop → validation)
+- Within each phase, list concrete tasks
+- Attach a validation gate to each phase — a checkpoint that must pass before the next phase begins
+- Flag known risks and mitigation strategies up front
+
+**Artifact — Project Timeline:**
+```
+Phase 1: <name>
+  Tasks:
+    - [ ] <task>
+    - [ ] <task>
+  Validation gate: <what must be true to proceed>
+
+Phase 2: <name>
+  Tasks:
+    - [ ] <task>
+  Validation gate: <what must be true to proceed>
+
+Known risks:
+  - Risk: <description> — Mitigation: <approach>
+
+Definition of done (prototype): <what the completed prototype delivers>
+```
+
+**Gate:** Plan reviewed for obvious gaps or sequencing errors before implementation begins. Pre-empt as many issues as possible here to avoid wasted effort during implementation.

--- a/plugins/terma/skills/writing-code/SKILL.md
+++ b/plugins/terma/skills/writing-code/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: writing-good-code
+description: Provides opinionated, Rich Hickey-inspired coding principles and style guidance for writing clean, readable, and intentional code. Use when writing new code, refactoring existing code, reviewing code quality, choosing between functions and classes, structuring modules, or applying functional and data-first programming principles — especially when prioritising simplicity, types-first design, and small focused routines over object-oriented patterns.
+---
+
 # Writing good code
 
 - prefer functions over classes unless managing resources
@@ -12,3 +17,96 @@
 write code like Rich Hickey
 
 Read and apply the guidance from @../../lib/code-style.md
+
+---
+
+## Concrete examples
+
+### Prefer functions over classes
+
+**Bad** — a class used purely for bundling stateless behaviour:
+```python
+class OrderCalculator:
+    def calculate_total(self, items):
+        return sum(item.price for item in items)
+
+    def apply_discount(self, total, rate):
+        return total * (1 - rate)
+```
+
+**Good** — plain functions; no hidden state, easier to test and compose:
+```python
+def calculate_total(items):
+    return sum(item.price for item in items)
+
+def apply_discount(total, rate):
+    return total * (1 - rate)
+```
+
+Use a class only when it genuinely manages a resource lifecycle (e.g., a database connection, a file handle).
+
+---
+
+### Write the types first
+
+Start by defining your data shapes before writing any logic. This forces clarity about what the program actually operates on.
+
+```typescript
+// 1. Types first
+type OrderId = string;
+type Money = { amount: number; currency: string };
+type LineItem = { productId: string; quantity: number; unitPrice: Money };
+type Order = { id: OrderId; items: LineItem[]; placedAt: Date };
+
+// 2. Then the functions — signatures are self-documenting
+function orderTotal(order: Order): Money { ... }
+function applyDiscount(total: Money, ratePercent: number): Money { ... }
+
+// 3. Then tests, then integration wiring
+```
+
+The types act as executable documentation: a reader knows the domain before reading a single line of logic.
+
+---
+
+### Flat code over nested logic
+
+**Bad** — deeply nested, hard to follow the story:
+```python
+def process(order):
+    if order:
+        if order.items:
+            for item in order.items:
+                if item.in_stock:
+                    ship(item)
+```
+
+**Good** — early returns keep the happy path flat and readable:
+```python
+def process(order):
+    if not order or not order.items:
+        return
+    for item in order.items:
+        if item.in_stock:
+            ship(item)
+```
+
+---
+
+### Review checklist
+
+Before submitting or finishing a piece of code, verify it against the core principles:
+
+- [ ] Functions preferred over classes where no resource lifecycle is managed
+- [ ] Types / signatures defined first and are self-documenting
+- [ ] No unnecessary nesting — early returns used where appropriate
+- [ ] Each routine is small and focused on one thing
+- [ ] Module names and structure tell the story of the domain
+- [ ] Change is the smallest possible; code is no messier than it was found
+- [ ] `code-style.md` rules applied (naming, imports, linting)
+
+---
+
+### What `code-style.md` contains
+
+`@../../lib/code-style.md` provides project-specific style rules (naming conventions, import ordering, linting configuration, and language-specific idioms). Always read it before writing or reviewing code in this project — it is the authoritative source for decisions not covered by the general principles above.

--- a/plugins/tsal/skills/claude-plugins/SKILL.md
+++ b/plugins/tsal/skills/claude-plugins/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: code-plugins-quick-reference
+description: Comprehensive quick reference for Claude Code plugins. Use when creating, installing, configuring, or troubleshooting Claude Code plugins; managing plugin marketplaces; setting up plugin manifests, skills, commands, hooks, LSP, or MCP integrations; converting standalone commands to plugins; or configuring team and scoped plugin installations.
+---
+
 # Claude Code Plugins Quick Reference
 
 Full docs:
@@ -87,6 +92,8 @@ claude plugin install plugin-name@marketplace-name --scope local
 # Uninstall
 /plugin uninstall plugin-name@marketplace-name
 ```
+
+**Verify installation**: Run `/plugin-name:command-name` to confirm the plugin loaded correctly, or open `/plugin` > Installed to check status.
 
 ### Interactive UI
 
@@ -240,4 +247,5 @@ Add to `.claude/settings.json` for automatic marketplace prompts:
 2. Copy `.claude/commands` to `my-plugin/commands/`
 3. Copy `.claude/skills` to `my-plugin/skills/`
 4. Move hooks from `settings.json` to `my-plugin/hooks/hooks.json`
-5. Test: `claude --plugin-dir ./my-plugin`
+5. **Validate**: Test with `claude --plugin-dir ./my-plugin` and confirm commands appear in `/help` (listed as `/my-plugin:command-name`)
+6. If validation passes, install or distribute the plugin; if commands are missing, check the `/plugin` Errors tab for loading issues

--- a/plugins/tsal/skills/domain-driven-design/SKILL.md
+++ b/plugins/tsal/skills/domain-driven-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain-driven-design
-description: This skill should be used whenever domain modeling is taking place. It provides specialized guidance for type-driven and data-driven design based on Rich Hickey and Scott Wlaschin's principles. The skill helps contextualize current modeling within the existing domain model, identifies inconsistencies, builds ubiquitous language, and creates visualizations (Mermaid, Graphviz/DOT, ASCII diagrams) to communicate domain concepts clearly. Use this skill when designing types, modeling business domains, refactoring domain logic, or ensuring domain consistency across a codebase.
+description: Applies domain-driven design (DDD) principles to define entities, value objects, and aggregates; map bounded contexts; enforce ubiquitous language; and create visualizations (Mermaid, Graphviz/DOT, ASCII) to communicate domain structure. Draws on Rich Hickey's data-oriented design and Scott Wlaschin's type-driven design to make illegal states unrepresentable and model workflows as explicit data transformations. Use when working on DDD, domain-driven design, entity modeling, aggregate design, value objects, bounded contexts, or event modeling — including designing types, modeling business domains, refactoring domain logic, resolving naming inconsistencies, or ensuring domain consistency across a codebase.
 ---
 
 # Domain-Driven Design
@@ -13,85 +13,27 @@ This skill provides guidance for domain modeling based on Rich Hickey's data-ori
 
 ### Rich Hickey's Data-Oriented Design
 
-**Simplicity over Ease**
-- Favor simple constructs that can be understood independently
-- Avoid complecting (intertwining) unrelated concerns
-- Separate policy from mechanism, data from behavior
-
-**Data is King**
-- Model the domain using pure data structures, not objects with behavior
-- Prefer generic data structures (maps, sets, vectors) over custom classes when appropriate
-- Data should be self-describing and inspectable
-- Functions transform data; data does not execute behavior
-
-**Value of Values**
-- Use immutable values to represent facts
-- Values enable local reasoning and simple equality
-- Values can be freely shared without coordination
-- Consider: what are the immutable facts in this domain?
-
-**Decomplecting**
-- Identify what is truly essential to the domain vs. incidental complexity
-- Separate when-it-happens from what-happens
-- Separate mechanism from policy
-- Question: are these concerns actually separate, or have we tangled them?
+- **Separate concerns**: Decouple policy from mechanism, data from behavior, when-it-happens from what-happens
+- **Data as pure facts**: Model the domain using plain data structures; functions transform data, data does not execute behavior
+- **Immutable values**: Use values to represent facts — they enable local reasoning and can be freely shared
+- **Decomplect**: Identify what is truly essential vs. incidental; question whether tangled concerns are actually related
 
 ### Scott Wlaschin's Type-Driven Design
 
-**Make Illegal States Unrepresentable**
-- Use the type system to eliminate invalid states at compile time
-- Model optional values explicitly (Option/Maybe types)
-- Use sum types (discriminated unions) for states that are mutually exclusive
-- Avoid primitive obsession; create domain-specific types
-
-**Domain Modeling Made Functional**
-- Model workflows as data transformations: Input → Process → Output
-- Explicitly model business rules as functions
-- Separate validation from business logic
-- Think in terms of: What can happen? What are the valid transitions?
-
-**Railway-Oriented Programming**
-- Model success and failure paths explicitly (Result types)
-- Chain operations that can fail using bind/flatMap
-- Keep the happy path clear and linear
-- Handle errors at appropriate boundaries
-
-**Types as Documentation**
-- Type signatures should communicate intent
-- Use newtype wrappers for semantic clarity (UserId, EmailAddress, Timestamp)
-- Constrain inputs to valid ranges using types
-- Let the type system guide API design
+- **Make illegal states unrepresentable**: Use sum types for mutually exclusive states; avoid primitive obsession; model optionals explicitly
+- **Workflows as transformations**: Model business rules as functions — `Input → Process → Output`; separate validation from business logic
+- **Railway-oriented programming**: Model success/failure explicitly with Result types; chain fallible operations with bind/flatMap
+- **Types as documentation**: Use newtype wrappers for semantic clarity (`UserId`, `EmailAddress`); let the type system guide API design
 
 ## DDD Building Blocks
 
 ### Entities vs Value Objects
 
-**Entities** are defined by identity, not attributes:
-- Have a unique identifier (ID, account number, etc.)
-- Can change over time while maintaining identity
-- Two entities with same attributes but different IDs are distinct
-- Used when domain experts refer to things by name/ID
-
-**Value Objects** are defined entirely by attributes:
-- No unique identifier
-- Immutable
-- Two value objects with same attributes are interchangeable
-- Used when only the value matters, not identity
-
 **Decision Guide:**
-- Ask: Do domain experts refer to this by ID/name? → Entity
-- Ask: Can I replace it with an equivalent copy? → If yes: Value Object
+- Ask: Do domain experts refer to this by ID/name, or does it change over time while maintaining identity? → **Entity**
+- Ask: Can I replace it with an equivalent copy? Does only the value matter, not who it is? → **Value Object** (immutable, no unique identifier)
 
 ### Aggregates and Aggregate Roots
-
-**Aggregate**: A cluster of entities and value objects treated as a single unit for data changes.
-
-**Aggregate Root**: The single entity through which all external access to the aggregate must pass.
-
-**Purpose:**
-- Define transactional consistency boundaries
-- Enforce invariants that span multiple objects
-- Simplify the model by grouping related concepts
 
 **Rules:**
 - External references go only to the aggregate root (use ID references)
@@ -106,54 +48,27 @@ This skill provides guidance for domain modeling based on Rich Hickey's data-ori
 
 ### Bounded Contexts
 
-**Definition**: An explicit boundary within which a domain model applies.
-
-**Purpose:**
-- Divide large domains into manageable pieces
-- Allow same term to have different meanings in different contexts
-- Prevent model corruption from mixing incompatible concepts
-
-**Key Insight**: Ubiquitous language is only ubiquitous within a context. "Customer" in Sales context may be different from "Customer" in Shipping context.
-
 **When modeling:**
-- Identify which bounded context you're in
+- Identify which bounded context you're in — ubiquitous language is only ubiquitous *within* a context ("Customer" in Sales may differ from "Customer" in Shipping)
 - Make context boundaries explicit in code structure (separate modules/namespaces)
 - Use anti-corruption layers when integrating across contexts
 - Document relationships between contexts (context map)
 
 ### Domain Events
 
-**Definition**: Something important that happened in the domain.
-
-**Characteristics:**
 - Named in past tense (OrderPlaced, PaymentProcessed, UserRegistered)
-- Immutable facts
-- Domain experts care about them
-- Can trigger reactions within or across bounded contexts
-
-**Uses:**
-- Decouple domain logic
-- Enable eventual consistency between aggregates
-- Integration between bounded contexts
-- Event sourcing (store events as source of truth)
+- Immutable facts that domain experts care about
+- Decouple domain logic, enable eventual consistency between aggregates, integrate bounded contexts, support event sourcing
 
 ### Repositories
 
-**Purpose**: Provide illusion of an in-memory collection of aggregates, abstracting persistence.
-
-**Characteristics:**
 - Operate at aggregate boundaries (load/save whole aggregates)
-- Provide lookup by ID
-- Hide database implementation details
+- Provide lookup by ID; hide database implementation details
 - Return domain entities, not database rows
-
-**Pattern**: Application layer uses repository to get/save aggregates; domain layer remains pure.
 
 ## Domain Modeling Workflow
 
 ### 1. Discover the Ubiquitous Language
-
-Start by identifying the domain concepts, using terminology from domain experts:
 
 **Action Items:**
 - List nouns (entities, value objects) and verbs (operations, events) from the domain
@@ -162,7 +77,6 @@ Start by identifying the domain concepts, using terminology from domain experts:
 - Ask: What does the business call this? What are the boundaries of this concept?
 
 **Output Format:**
-Create a glossary section documenting each term:
 ```markdown
 **Term** (Type: Entity/ValueObject/Event/Command)
 - Definition: [Clear, domain-expert-approved definition]
@@ -171,8 +85,6 @@ Create a glossary section documenting each term:
 ```
 
 ### 2. Analyze the Existing Domain Model
-
-Before making changes, understand the current state:
 
 **Exploration Steps:**
 - Identify where domain concepts are currently modeled (types, schemas, tables)
@@ -188,8 +100,6 @@ Before making changes, understand the current state:
 - Are there phantom types or states that shouldn't exist?
 
 ### 3. Identify Inconsistencies and Smells
-
-Common problems to surface:
 
 **Naming Inconsistencies**
 - Same concept with different names (User vs Account vs Customer)
@@ -214,15 +124,6 @@ Common problems to surface:
 
 ### 4. Design the Domain Model
 
-Apply type-driven and data-driven principles:
-
-**Data Modeling:**
-- Start with the data shape; what are the facts?
-- Use immutable values for facts that don't change
-- Model state transitions explicitly
-- Separate identity from attributes
-- Consider: what varies together? What varies independently?
-
 **Type Design:**
 - Create sum types for mutually exclusive states:
   ```
@@ -237,7 +138,13 @@ Apply type-driven and data-driven principles:
   type EmailAddress = EmailAddress of string  // with validation
   type Money = { amount: Decimal, currency: Currency }
   ```
-- Make impossible states unrepresentable
+
+**Data Modeling:**
+- Start with the data shape; what are the facts?
+- Use immutable values for facts that don't change
+- Model state transitions explicitly
+- Separate identity from attributes
+- Consider: what varies together? What varies independently?
 
 **Workflow Modeling:**
 - Model each business workflow as a clear pipeline:
@@ -262,15 +169,7 @@ Apply type-driven and data-driven principles:
 - Module boundaries should follow domain boundaries
 - Comments should explain domain rules, not implementation details
 
-**Documentation:**
-- Keep the glossary up to date
-- Document why decisions were made (especially constraints and invariants)
-- Link code to domain documentation
-- Make implicit domain rules explicit
-
 ### 6. Visualize the Domain Model
-
-Use diagrams to communicate domain structure and relationships:
 
 **Mermaid for Relationships:**
 ```mermaid
@@ -352,35 +251,14 @@ Customer
 
 ## Domain Modeling Anti-Patterns
 
-**Anemic Domain Model**
-- Symptom: Data structures with getters/setters, all logic in separate services
-- Problem: Violates data-orientation by adding ceremony without encapsulation benefits
-- Solution: Keep data as data; put related transformations in same module but separate from data definition
-
-**Entity Services Anti-Pattern**
-- Symptom: Classes like `UserService`, `OrderManager`, `ProductFactory`
-- Problem: Hides actual operations; lacks ubiquitous language
-- Solution: Name functions after domain operations: `approveOrder`, `cancelSubscription`, `calculateDiscount`
-
-**Primitive Obsession**
-- Symptom: String for email, number for money, boolean flags for states
-- Problem: No type safety; invalid values representable
-- Solution: Create semantic types with validation
-
-**Accidental Complexity**
-- Symptom: Complex abstractions, design patterns without clear domain benefit
-- Problem: Adds layers that obscure domain meaning
-- Solution: Simplify; prefer composition over inheritance; avoid premature abstraction
-
-**Hidden Temporal Coupling**
-- Symptom: Must call methods in specific order or system breaks
-- Problem: Complects workflow with state management
-- Solution: Make workflow explicit; use types to enforce valid transitions
-
-**Boolean Blindness**
-- Symptom: Boolean flags to represent states (isApproved, isActive, isDeleted)
-- Problem: Multiple booleans can represent impossible states
-- Solution: Use sum types for mutually exclusive states
+| Anti-Pattern | Symptom | Solution |
+|---|---|---|
+| **Anemic Domain Model** | Data structures with getters/setters; all logic in separate services | Keep data as data; put related transformations in the same module but separate from data definition |
+| **Entity Services** | Classes like `UserService`, `OrderManager`, `ProductFactory` | Name functions after domain operations: `approveOrder`, `cancelSubscription`, `calculateDiscount` |
+| **Primitive Obsession** | String for email, number for money, boolean flags for states | Create semantic types with validation |
+| **Accidental Complexity** | Complex abstractions or design patterns without clear domain benefit | Simplify; prefer composition over inheritance; avoid premature abstraction |
+| **Hidden Temporal Coupling** | Must call methods in specific order or system breaks | Make workflow explicit; use types to enforce valid transitions |
+| **Boolean Blindness** | Multiple boolean flags to represent states (`isApproved`, `isActive`, `isDeleted`) | Use sum types for mutually exclusive states |
 
 ## Contextualizing Within Existing Models
 
@@ -402,8 +280,6 @@ When adding to or changing an existing domain model:
 - Can we make this change incrementally?
 
 ## Checklist for Domain Modeling
-
-Before completing domain modeling work:
 
 **Language & Communication:**
 - [ ] All domain concepts are named using ubiquitous language

--- a/plugins/tsal/skills/godot-interactive/SKILL.md
+++ b/plugins/tsal/skills/godot-interactive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: godot-interactive
-description: "Interact with a running Godot game via MCP — launch, screenshot, click, inspect scene tree, get/set properties. Powered by godot-mcp + GodotMCPBridge autoload."
+description: "Interact with a running Godot game via MCP — launch, screenshot, click, inspect scene tree, get/set properties. Powered by godot-mcp + GodotMCPBridge autoload. Use when debugging Godot games, testing game behavior, automating game interactions, or validating UI layouts in a Godot project. Useful for game development workflows involving automated UI testing, visual debugging, verifying game state, or creating reproducible test scenarios for .gd / GDScript-based projects."
 ---
 
 # Godot Interactive Testing Skill
@@ -9,21 +9,7 @@ Playwright-like interaction loop for Godot games via MCP. Launch, observe, click
 
 ## Overview
 
-This skill enables LLM-driven interactive testing of Godot games through the godot-mcp MCP server and a GodotMCPBridge autoload. You can:
-
-- Launch and stop Godot projects via MCP
-- Capture viewport screenshots automatically or on-demand
-- Inspect the scene tree with Control node positions and text
-- Simulate clicks, key presses, and input actions
-- Read and write node properties at runtime
-- Implement iterative test/debug loops (observe → inspect → interact → observe)
-
-This is particularly useful for:
-- Automated UI testing
-- Debugging visual issues
-- Verifying game state without manual playtesting
-- Creating reproducible test scenarios
-- Validating UI layouts and interactions
+This skill enables LLM-driven interactive testing of Godot games through the godot-mcp MCP server and a GodotMCPBridge autoload. The core loop is: **observe → inspect → interact → verify** (see Core Workflow below).
 
 ## Prerequisites
 
@@ -31,9 +17,6 @@ This is particularly useful for:
 - Installed at `~/code/godot-mcp` (or configurable path)
 - Built with `npm install && npm run build`
 - Repository: https://github.com/yourusername/godot-mcp
-
-**Claude Desktop configuration:**
-- MCP server configured in `~/.claude/mcp.json` (see Setup)
 
 **Godot project setup:**
 - GodotMCPBridge autoload installed
@@ -43,7 +26,6 @@ This is particularly useful for:
 
 ### 1. Copy the Bridge Autoload
 
-Copy the bridge script into your project:
 ```bash
 cp assets/templates/godot_mcp_bridge.gd res://scripts/autoload/godot_mcp_bridge.gd
 ```
@@ -53,19 +35,13 @@ cp assets/templates/godot_mcp_bridge.gd res://scripts/autoload/godot_mcp_bridge.
 Add to `project.godot`:
 ```ini
 [autoload]
-
 GodotMCPBridge="*res://scripts/autoload/godot_mcp_bridge.gd"
 ```
 
-Or via Godot editor:
-- Project → Project Settings → Autoload
-- Path: `res://scripts/autoload/godot_mcp_bridge.gd`
-- Name: `GodotMCPBridge`
-- Enable: Yes
+Or via editor: Project → Project Settings → Autoload → add `GodotMCPBridge`.
 
 ### 3. Create MCP Configuration
 
-Create `.mcp.json` at project root (use template):
 ```bash
 cp assets/templates/mcp.json.template .mcp.json
 ```
@@ -85,781 +61,110 @@ Edit paths:
 }
 ```
 
-**Example paths:**
-- macOS: `/Applications/Godot 4.5.app/Contents/MacOS/Godot`
-- Linux: `/usr/bin/godot` or `~/godot/bin/godot`
-- Windows: `C:/Godot/godot.exe`
-
-**Project-local godot-mcp:**
-If you keep godot-mcp in your project (e.g., `.tools/godot-mcp`):
-```json
-"args": [".tools/godot-mcp/build/index.js"]
-```
-
 ## MCP Tools Reference
 
-All tools are provided by the godot-mcp server and work through the GodotMCPBridge autoload.
+| Tool | Purpose | Key Notes |
+|---|---|---|
+| `run_project(projectPath)` | Launch project with remote debugger | Wait 2–3 s or poll `get_debug_output()` before other calls |
+| `stop_project()` | Stop the running project | Always call when done |
+| `get_debug_output()` | Retrieve stdout/stderr (most recent first) | Confirm bridge startup: "Godot MCP Bridge initialized" |
+| `game_screenshot()` | Capture viewport as base64 PNG | Use this, not upstream DAP `capture_screenshot` |
+| `game_scene_tree(path?, depth?)` | Inspect scene tree with types, `rect`, `visible`, `text` | Default: `/root`, depth 3; `rect` is full-window coordinates |
+| `game_click(x, y, button?)` | Simulate mouse click; auto-screenshot 200 ms after | `button`: 1=left (default), 2=right, 3=middle |
+| `game_key(key)` | Simulate key press (Godot key names, case-sensitive) | E.g. `"Space"`, `"Escape"`, `"Enter"`, `"F1"`–`"F12"` |
+| `game_action(name)` | Trigger an InputMap action by name | Action must exist in project's InputMap |
+| `game_get_property(node_path, property)` | Read a node property at runtime | Vectors returned as `{x,y,z}`, Color as `{r,g,b,a}` |
+| `game_set_property(node_path, property, value)` | Write a node property; auto-screenshot 100 ms after | Use JSON objects for vectors: `{x, y}` or `{x, y, z}` |
 
-### run_project(projectPath)
+**⚠️ Key gotcha:** UI coordinates are full window resolution (e.g., 1920×1080), not screenshot pixel coordinates. Always use `game_scene_tree` `rect` values for click coordinates — never guess from screenshot pixels.
 
-Launch a Godot project with remote debugger enabled.
+## Core Workflow: Observe → Inspect → Interact → Verify
 
-**Parameters:**
-- `projectPath` (string): Absolute path to project directory containing `project.godot`
-
-**Returns:**
-- Success confirmation with process ID
-
-**Example:**
 ```typescript
+// 1. Launch and confirm startup
 run_project({ projectPath: "/Users/ben/code/my-game" })
-```
+get_debug_output()  // Wait for "Godot MCP Bridge initialized"
 
-**Notes:**
-- Automatically enables remote debugger on port 6007
-- Takes 2-3 seconds for project to fully start
-- Bridge begins auto-capturing screenshots every 2 seconds
-- Check `get_debug_output()` if game doesn't appear to start
+// 2. Observe initial state
+game_screenshot()
 
-### stop_project()
+// 3. Inspect scene tree to find button position
+game_scene_tree({ path: "/root/Main/UILayer", depth: 3 })
+// Find: { name: "PlayButton", rect: {x: 860, y: 520, w: 200, h: 80} }
 
-Stop the currently running Godot project.
+// 4. Click button center (use rect, not screenshot pixels)
+game_click({ x: 960, y: 560 })
 
-**Parameters:** None
+// 5. Verify result visually and via state
+game_screenshot()
+game_get_property({ node_path: "/root/Main", property: "state" })
+get_debug_output()
 
-**Returns:**
-- Success confirmation
-
-**Example:**
-```typescript
+// 6. Clean up
 stop_project()
 ```
 
-**Notes:**
-- Kills the Godot process gracefully
-- Cleans up debugger connection
-- Safe to call even if no project is running
+### Forcing Game States for Testing
 
-### get_debug_output()
+Skip manual play to reach specific scenarios:
 
-Retrieve stdout/stderr from the running Godot process.
-
-**Parameters:** None
-
-**Returns:**
-- Array of log lines (most recent first)
-
-**Example:**
 ```typescript
-get_debug_output()
-// Returns: ["Frame 1234", "Button pressed", "MCP command: click", ...]
-```
+run_project({ projectPath: "/path/to/game" })
 
-**Use cases:**
-- Check if game started successfully
-- Debug print statements from your game
-- Verify bridge initialization ("Godot MCP Bridge initialized")
-- Inspect error messages
+// Jump to level 5
+game_set_property({ node_path: "/root/Main", property: "current_level", value: 5 })
 
-### game_screenshot()
-
-Capture the current viewport and return as base64 image.
-
-**Parameters:** None
-
-**Returns:**
-- Base64-encoded PNG image of the game viewport
-
-**Example:**
-```typescript
-game_screenshot()
-// Returns: base64 PNG data
-```
-
-**Notes:**
-- Captures the main viewport at full resolution
-- Bridge auto-saves screenshots to `/tmp/godot_screenshot.png` every 2 seconds
-- This tool provides immediate capture via MCP response
-- Works on stock Godot (unlike `capture_screenshot` from upstream DAP)
-
-### game_scene_tree(path, depth)
-
-Inspect the scene tree with node types, positions, and properties.
-
-**Parameters:**
-- `path` (string, optional): Root path to start inspection, default: `/root`
-- `depth` (number, optional): Traversal depth, default: 3
-
-**Returns:**
-- JSON tree structure with nodes
-
-**Node properties:**
-- `name`: Node name
-- `type`: Node class (Control, Button, Label, Node3D, etc.)
-- `rect`: For Control nodes: `{x, y, w, h}` in screen coordinates
-- `visible`: For Control nodes: visibility state
-- `text`: For Button/Label nodes: display text
-- `children`: Array of child nodes (up to depth limit)
-
-**Example:**
-```typescript
-game_scene_tree({ path: "/root/Main/UILayer", depth: 2 })
-// Returns:
-{
-  "name": "UILayer",
-  "type": "CanvasLayer",
-  "children": [
-    {
-      "name": "VictoryPopup",
-      "type": "CenterContainer",
-      "rect": {"x": 640, "y": 360, "w": 400, "h": 200},
-      "visible": true,
-      "children": [
-        {
-          "name": "OKButton",
-          "type": "Button",
-          "rect": {"x": 720, "y": 480, "w": 80, "h": 40},
-          "text": "OK",
-          "visible": true
-        }
-      ]
-    }
-  ]
-}
-```
-
-**Use cases:**
-- Find clickable UI elements (buttons, controls)
-- Verify UI layout and positioning
-- Check visibility states
-- Locate nodes by name/type for property access
-
-**Key gotcha:** UI coordinates are full resolution (e.g., 1920x1080), not screenshot pixel coordinates. Always use `game_scene_tree` to get accurate `rect` values for clicking.
-
-### game_click(x, y, button)
-
-Simulate a mouse click at screen coordinates.
-
-**Parameters:**
-- `x` (number): Screen X coordinate
-- `y` (number): Screen Y coordinate
-- `button` (number, optional): Mouse button index, default: 1 (left click)
-  - 1: Left button (MOUSE_BUTTON_LEFT)
-  - 2: Right button (MOUSE_BUTTON_RIGHT)
-  - 3: Middle button (MOUSE_BUTTON_MIDDLE)
-
-**Returns:**
-- Success confirmation with coordinates
-- Automatically captures screenshot after click
-
-**Example:**
-```typescript
-game_click({ x: 720, y: 480, button: 1 })
-// Returns: {"type": "click", "success": true, "x": 720, "y": 480}
-```
-
-**Notes:**
-- Simulates press + release with 50ms delay
-- Takes a screenshot 200ms after release
-- Use `game_scene_tree` to find button `rect` coordinates
-- Coordinates are in full window resolution, not SubViewport pixels
-
-**Workflow:**
-1. Call `game_screenshot()` to see the game
-2. Call `game_scene_tree()` to find button positions
-3. Call `game_click()` with button's center coordinates
-4. Call `game_screenshot()` to verify result
-
-### game_key(key)
-
-Simulate a key press using Godot key names.
-
-**Parameters:**
-- `key` (string): Godot key name (e.g., "Space", "Escape", "Enter", "A")
-
-**Returns:**
-- Success confirmation
-- Automatically captures screenshot after key press
-
-**Example:**
-```typescript
-game_key({ key: "Space" })
-game_key({ key: "Escape" })
-game_key({ key: "Q" })
-```
-
-**Common key names:**
-- Letters: "A", "B", "C", etc.
-- Numbers: "0", "1", "2", etc.
-- Special: "Space", "Enter", "Escape", "Tab"
-- Arrows: "Up", "Down", "Left", "Right"
-- Function: "F1", "F2", etc.
-
-**Notes:**
-- Uses `OS.find_keycode_from_string()` - must be valid Godot key name
-- Simulates press + release with 50ms delay
-- Takes screenshot 200ms after release
-- Case-sensitive for letters (use uppercase "A", not "a")
-
-### game_action(name)
-
-Trigger a Godot input action defined in InputMap.
-
-**Parameters:**
-- `name` (string): Action name from project InputMap
-
-**Returns:**
-- Success confirmation
-- Automatically captures screenshot after action
-
-**Example:**
-```typescript
-game_action({ name: "jump" })
-game_action({ name: "ui_accept" })
-game_action({ name: "shoot" })
-```
-
-**Notes:**
-- Action must be defined in project's InputMap (project.godot)
-- Simulates action press + release with 50ms delay
-- Takes screenshot 200ms after release
-- Works with multi-key bindings (triggers the action, not specific keys)
-
-**Use cases:**
-- Test gameplay actions without knowing exact key bindings
-- Trigger complex input combinations (e.g., "dash" = Shift+W)
-- Test controller/gamepad actions
-
-### game_get_property(node_path, property)
-
-Read a node property at runtime.
-
-**Parameters:**
-- `node_path` (string): Absolute node path from `/root` (e.g., `/root/Main/Player`)
-- `property` (string): Property name (e.g., `position`, `health`, `visible`)
-
-**Returns:**
-- Property value (JSON-serialized)
-
-**Example:**
-```typescript
-game_get_property({ node_path: "/root/Main/Player", property: "position" })
-// Returns: {"x": 5.2, "y": 0.0, "z": 3.8}
-
-game_get_property({ node_path: "/root/Main/UILayer/HUD", property: "visible" })
-// Returns: true
-```
-
-**Supported types:**
-- Primitives: bool, int, float, String
-- Vectors: Vector2, Vector2i, Vector3, Vector3i (as `{x, y, z}`)
-- Color: `{r, g, b, a}`
-- Arrays/Dictionaries: recursively converted
-- Objects: `"<ClassName>"`
-- NodePath: string representation
-
-**Use cases:**
-- Verify game state (player health, position, score)
-- Check UI visibility and text
-- Validate object properties after interactions
-
-### game_set_property(node_path, property, value)
-
-Write a node property at runtime.
-
-**Parameters:**
-- `node_path` (string): Absolute node path from `/root`
-- `property` (string): Property name
-- `value` (any): New value (JSON-serializable)
-
-**Returns:**
-- Success confirmation
-- Automatically captures screenshot after change
-
-**Example:**
-```typescript
-game_set_property({
-  node_path: "/root/Main/Player",
-  property: "position",
-  value: { x: 10, y: 0, z: 5 }
-})
-
+// Force victory popup visible
 game_set_property({
   node_path: "/root/Main/UILayer/VictoryPopup",
   property: "visible",
   value: true
 })
+
+game_screenshot()
+game_click({ x: 760, y: 500 })  // Click OK using rect from game_scene_tree
+stop_project()
 ```
 
-**Notes:**
-- Takes screenshot 100ms after property change
-- Use JSON object syntax for Vector2/Vector3: `{x, y}` or `{x, y, z}`
-- For testing, you can force game states (show popups, move player, etc.)
+### Debugging Visual Issues
 
-**Use cases:**
-- Force UI visibility for testing
-- Teleport player to test positions
-- Set health/score to test edge cases
-- Trigger game states without playing through
-
-## Workflow Patterns
-
-### Pattern 1: Basic UI Test Loop
-
-Test a button click and verify the result.
-
-**Steps:**
-
-1. **Launch the game:**
-   ```typescript
-   run_project({ projectPath: "/Users/ben/code/my-game" })
-   ```
-
-2. **Wait for startup (check logs):**
-   ```typescript
-   get_debug_output()
-   // Look for "Godot MCP Bridge initialized"
-   ```
-
-3. **Observe initial state:**
-   ```typescript
-   game_screenshot()
-   ```
-
-4. **Inspect scene tree to find button:**
-   ```typescript
-   game_scene_tree({ path: "/root/Main/UILayer", depth: 3 })
-   // Note the button's rect: {x: 720, y: 480, w: 80, h: 40}
-   ```
-
-5. **Click button center:**
-   ```typescript
-   game_click({ x: 760, y: 500 })  // Center of button
-   ```
-
-6. **Verify result:**
-   ```typescript
-   game_screenshot()  // See visual result
-   get_debug_output()  // Check for print statements
-   ```
-
-### Pattern 2: Property Inspection and Validation
-
-Verify game state after actions.
-
-**Steps:**
-
-1. **Launch and perform action:**
-   ```typescript
-   run_project({ projectPath: "/path/to/game" })
-   game_click({ x: 640, y: 360 })  // Click play button
-   ```
-
-2. **Read game state:**
-   ```typescript
-   game_get_property({ node_path: "/root/Main/Player", property: "health" })
-   // Returns: 100
-
-   game_get_property({ node_path: "/root/Main/Ball", property: "position" })
-   // Returns: {"x": 0, "y": 0, "z": 0}
-   ```
-
-3. **Trigger gameplay:**
-   ```typescript
-   game_action({ name: "select_card" })
-   ```
-
-4. **Verify state change:**
-   ```typescript
-   game_get_property({ node_path: "/root/Main/Ball", property: "position" })
-   // Returns: {"x": 5, "y": 0, "z": 3}  // Ball moved!
-   ```
-
-### Pattern 3: Forcing Game States for Testing
-
-Set up specific scenarios without manual play.
-
-**Steps:**
-
-1. **Launch game:**
-   ```typescript
-   run_project({ projectPath: "/path/to/game" })
-   ```
-
-2. **Force victory state:**
-   ```typescript
-   game_set_property({
-     node_path: "/root/Main",
-     property: "state",
-     value: "VICTORY"
-   })
-   ```
-
-3. **Show victory popup:**
-   ```typescript
-   game_set_property({
-     node_path: "/root/Main/UILayer/VictoryPopup",
-     property: "visible",
-     value: true
-   })
-   ```
-
-4. **Verify UI appears correctly:**
-   ```typescript
-   game_screenshot()
-   game_scene_tree({ path: "/root/Main/UILayer/VictoryPopup" })
-   ```
-
-5. **Test OK button:**
-   ```typescript
-   game_click({ x: 760, y: 500 })
-   ```
-
-### Pattern 4: Debugging Visual Issues
-
-Investigate rendering problems.
-
-**Steps:**
-
-1. **Launch game:**
-   ```typescript
-   run_project({ projectPath: "/path/to/game" })
-   ```
-
-2. **Capture screenshot:**
-   ```typescript
-   game_screenshot()
-   // Observe: button is not visible
-   ```
-
-3. **Inspect button properties:**
-   ```typescript
-   game_get_property({ node_path: "/root/Main/UILayer/PlayButton", property: "visible" })
-   // Returns: false  // Aha! Button is hidden
-   ```
-
-4. **Check parent visibility:**
-   ```typescript
-   game_get_property({ node_path: "/root/Main/UILayer", property: "visible" })
-   // Returns: true
-   ```
-
-5. **Fix the bug** (in code):
-   ```gdscript
-   # In your script:
-   $PlayButton.visible = true  # Was missing this line
-   ```
-
-6. **Restart and verify:**
-   ```typescript
-   stop_project()
-   run_project({ projectPath: "/path/to/game" })
-   game_screenshot()
-   ```
-
-## Key Gotchas
-
-### Gotcha 1: UI Coordinates Are Full Resolution
-
-**Problem:** Screenshots are 640x360 (SubViewport), but UI coordinates are 1920x1080 (window resolution).
-
-**Solution:** Always use `game_scene_tree` to get button `rect` values. Do not manually calculate click coordinates from screenshot pixels.
-
-**Example:**
-```typescript
-// ❌ WRONG: Clicking screenshot pixel coordinates
-game_screenshot()  // 640x360 image
-game_click({ x: 320, y: 180 })  // Center of screenshot = WRONG
-
-// ✅ CORRECT: Use scene_tree rect
-game_scene_tree({ path: "/root/Main/UILayer" })
-// Returns: { name: "PlayButton", rect: {x: 860, y: 520, w: 200, h: 80} }
-game_click({ x: 960, y: 560 })  // Center of rect = CORRECT
-```
-
-### Gotcha 2: Stock Godot DAP Limitation
-
-**Problem:** The upstream Godot DAP `capture_screenshot` tool doesn't work on stock Godot builds.
-
-**Solution:** Use `game_screenshot()` from this skill instead. It works through the file-based bridge protocol (`/tmp/godot_screenshot.png`).
-
-**Why it matters:** Other Godot DAP tools may advertise `capture_screenshot`, but it requires a custom Godot build with DAP screenshot support. The bridge's `game_screenshot()` always works.
-
-### Gotcha 3: Bridge Initialization Delay
-
-**Problem:** Calling MCP tools immediately after `run_project()` may fail if bridge isn't ready.
-
-**Solution:** Check `get_debug_output()` for "Godot MCP Bridge initialized" before calling game interaction tools.
-
-**Example:**
 ```typescript
 run_project({ projectPath: "/path/to/game" })
-// Wait 2-3 seconds or poll debug output
-get_debug_output()
-// Look for: "Godot MCP Bridge initialized — screenshots: /tmp/godot_screenshot.png..."
-```
+game_screenshot()  // Observe: button not visible
 
-### Gotcha 4: Scene Tree Depth Limit
+game_get_property({ node_path: "/root/Main/UILayer/PlayButton", property: "visible" })
+// Returns: false — button is hidden
 
-**Problem:** `game_scene_tree()` defaults to depth 3, may not show deeply nested nodes.
-
-**Solution:** Increase `depth` parameter for deeper inspection, or query specific subtrees.
-
-**Example:**
-```typescript
-// Shallow inspection
-game_scene_tree({ path: "/root/Main", depth: 2 })
-
-// Deep inspection of UI subtree
-game_scene_tree({ path: "/root/Main/UILayer/VictoryPopup", depth: 5 })
-```
-
-### Gotcha 5: File-Based Protocol Synchronization
-
-**Problem:** Bridge uses file-based communication (`/tmp/godot_mcp_command.json` and `/tmp/godot_mcp_response.json`), which is polled every frame.
-
-**Solution:** MCP tools handle synchronization automatically. Response is written after command completes. No manual delays needed.
-
-**How it works:**
-1. MCP tool writes command to `/tmp/godot_mcp_command.json`
-2. Bridge polls the file every frame
-3. Bridge executes command and deletes command file
-4. Bridge writes response to `/tmp/godot_mcp_response.json`
-5. Bridge prints `MCP_RESPONSE:{...}` to stdout
-6. MCP tool reads response and returns to caller
-
-**You don't need to do anything special** - just call the tools normally.
-
-## Bridge Communication Protocol
-
-The GodotMCPBridge autoload implements a file-based protocol for communication:
-
-**Command file:** `/tmp/godot_mcp_command.json`
-- MCP server writes JSON commands here
-- Bridge polls every frame
-- Bridge deletes after reading
-
-**Response file:** `/tmp/godot_mcp_response.json`
-- Bridge writes JSON responses here
-- MCP server reads responses
-
-**Screenshot file:** `/tmp/godot_screenshot.png`
-- Bridge auto-saves every 2 seconds
-- Bridge updates after clicks/keys (200ms delay)
-- MCP tools can read this file directly
-
-**Debug output:**
-- Bridge prints `MCP_RESPONSE:{...}` to stdout
-- MCP server captures via `get_debug_output()`
-
-**Command format:**
-```json
-{
-  "action": "click",
-  "x": 640,
-  "y": 360,
-  "button": 1
-}
-```
-
-**Response format:**
-```json
-{
-  "type": "click",
-  "success": true,
-  "x": 640,
-  "y": 360
-}
+// Fix in code, then restart and verify:
+stop_project()
+run_project({ projectPath: "/path/to/game" })
+game_screenshot()
 ```
 
 ## Best Practices
 
-### 1. Always Inspect Before Clicking
-
-Use `game_scene_tree` to find button positions - don't guess coordinates.
-
-```typescript
-// ✅ CORRECT workflow
-game_scene_tree({ path: "/root/Main/UILayer" })
-// Find button rect
-game_click({ x: rect.x + rect.w/2, y: rect.y + rect.h/2 })
-
-// ❌ WRONG workflow
-game_screenshot()
-// Guess coordinates from image
-game_click({ x: 640, y: 360 })
-```
-
-### 2. Check Debug Output for Errors
-
-After interactions, check `get_debug_output()` for print statements and errors.
-
-```typescript
-game_click({ x: 640, y: 360 })
-get_debug_output()
-// Look for "Button pressed" or error messages
-```
-
-### 3. Use Property Inspection for Validation
-
-Don't just rely on screenshots - verify internal game state.
-
-```typescript
-game_click({ x: 640, y: 360 })
-game_get_property({ node_path: "/root/Main/Player", property: "health" })
-// Confirm health decreased as expected
-```
-
-### 4. Force States for Faster Testing
-
-Use `game_set_property` to skip to specific game states.
-
-```typescript
-// Skip tutorial, go straight to level 5
-game_set_property({ node_path: "/root/Main", property: "current_level", value: 5 })
-```
-
-### 5. Clean Up After Tests
-
-Always stop the project when done to free resources.
-
-```typescript
-stop_project()
-```
-
-## Common Use Cases
-
-### Use Case 1: Automated UI Regression Testing
-
-Test that buttons still work after code changes.
-
-```typescript
-run_project({ projectPath: "/path/to/game" })
-game_screenshot()
-game_scene_tree({ path: "/root/Main/UILayer" })
-game_click({ x: 640, y: 360 })  // Play button
-game_get_property({ node_path: "/root/Main", property: "state" })
-// Assert: state is "PLAYING"
-stop_project()
-```
-
-### Use Case 2: Visual Debugging
-
-Investigate why a UI element doesn't appear.
-
-```typescript
-run_project({ projectPath: "/path/to/game" })
-game_screenshot()  // See the issue
-game_scene_tree({ path: "/root/Main/UILayer" })  // Check hierarchy
-game_get_property({ node_path: "/root/Main/UILayer/MissingButton", property: "visible" })
-// Debug: visible is false!
-```
-
-### Use Case 3: Game State Validation
-
-Verify gameplay logic by checking properties.
-
-```typescript
-run_project({ projectPath: "/path/to/game" })
-game_action({ name: "attack" })
-game_get_property({ node_path: "/root/Main/Enemy", property: "health" })
-// Verify: health decreased correctly
-```
-
-### Use Case 4: Screenshot Documentation
-
-Capture screenshots of all UI states for documentation.
-
-```typescript
-run_project({ projectPath: "/path/to/game" })
-game_screenshot()  // Main menu
-game_click({ x: 640, y: 360 })  // Start game
-game_screenshot()  // Gameplay
-game_set_property({ node_path: "/root/Main/Popup", property: "visible", value: true })
-game_screenshot()  // Settings popup
-```
+1. **Always use `game_scene_tree` for coordinates** — never guess click positions from screenshot pixels
+2. **Check `get_debug_output()` after interactions** — look for print statements and errors
+3. **Validate internal state, not just visuals** — use `game_get_property` to confirm game logic
+4. **Use `game_set_property` to skip setup** — force states rather than playing through manually
+5. **Always call `stop_project()` when done** — free resources
 
 ## Troubleshooting
 
-### Game Won't Start
-
-**Symptoms:** `run_project()` succeeds but no screenshot appears.
-
-**Check:**
-1. Verify Godot path in `.mcp.json` is correct
-2. Check `get_debug_output()` for errors
-3. Ensure bridge autoload is registered in `project.godot`
-
-**Solution:**
-```typescript
-get_debug_output()
-// Look for "Godot MCP Bridge initialized"
-// If missing, bridge isn't loaded
-```
-
-### Click Doesn't Work
-
-**Symptoms:** `game_click()` succeeds but button doesn't respond.
-
-**Check:**
-1. Coordinates are correct (use `game_scene_tree`)
-2. Button is visible (`game_get_property`)
-3. UI is not blocked by another node
-
-**Solution:**
-```typescript
-game_scene_tree({ path: "/root/Main/UILayer" })
-// Verify button rect
-game_get_property({ node_path: "/root/Main/UILayer/Button", property: "visible" })
-// Verify button is visible
-```
-
-### Property Not Found
-
-**Symptoms:** `game_get_property()` returns error "Node not found".
-
-**Check:**
-1. Node path is correct (use `game_scene_tree` to find path)
-2. Node exists at runtime (may be dynamically created)
-
-**Solution:**
-```typescript
-game_scene_tree({ path: "/root/Main", depth: 5 })
-// Find the correct node path
-```
-
-### Screenshot Is Black/Empty
-
-**Symptoms:** Screenshot is solid black or shows nothing.
-
-**Check:**
-1. Game has finished rendering (wait 2-3 seconds after launch)
-2. Camera is active and positioned correctly
-3. Scene has visible nodes
-
-**Solution:**
-```typescript
-run_project({ projectPath: "/path/to/game" })
-// Wait 3 seconds
-get_debug_output()
-// Check for "Frame N" output indicating rendering
-game_screenshot()
-```
+| Symptom | Check | Solution |
+|---|---|---|
+| Game won't start / black screenshot | Godot path in `.mcp.json`, bridge autoload registered | `get_debug_output()` — look for "Godot MCP Bridge initialized" |
+| Click doesn't work | Coordinates correct? Button visible? Blocked by another node? | `game_scene_tree()` + `game_get_property(..., "visible")` |
+| "Node not found" from `game_get_property` | Node path correct? Node exists at runtime? | `game_scene_tree({ depth: 5 })` to find correct path |
+| Screenshot is black | Game still rendering after launch | Wait 3 seconds; check `get_debug_output()` for "Frame N" output |
+| Tools fail immediately after `run_project` | Bridge not initialized yet | Poll `get_debug_output()` for "Godot MCP Bridge initialized" before calling tools |
 
 ## Summary
 
-The godot-interactive skill enables automated testing and debugging of Godot games through MCP tools:
-
-1. **Launch games** with `run_project()` and remote debugger
-2. **Observe state** with `game_screenshot()` and `game_scene_tree()`
+1. **Launch** with `run_project()` → confirm with `get_debug_output()`
+2. **Observe** with `game_screenshot()` + `game_scene_tree()`
 3. **Interact** with `game_click()`, `game_key()`, `game_action()`
-4. **Inspect/modify** with `game_get_property()` and `game_set_property()`
-5. **Iterate** in a test loop until behavior is verified
+4. **Inspect/modify** with `game_get_property()` + `game_set_property()`
+5. **Iterate** until behavior is verified, then `stop_project()`
 
-**Key insights:**
-- File-based protocol is reliable and works on stock Godot
-- Always use `game_scene_tree` for accurate UI coordinates
-- Bridge autoload handles all synchronization automatically
-- Property inspection validates internal state, not just visuals
-
-This skill transforms Godot development from manual playtesting to automated, reproducible test scenarios.
+**Key insights:** Always use `game_scene_tree` for accurate UI coordinates. Bridge autoload handles all synchronization automatically. `game_screenshot()` works on stock Godot; upstream DAP `capture_screenshot` does not.

--- a/plugins/tsal/skills/shadertoy/SKILL.md
+++ b/plugins/tsal/skills/shadertoy/SKILL.md
@@ -1,23 +1,9 @@
 ---
 name: shadertoy
-description: This skill should be used when working with Shadertoy shaders, GLSL fragment shaders, or creating procedural graphics for the web. Use when writing .glsl files, implementing visual effects, creating generative art, or working with WebGL shader code. This skill provides GLSL ES syntax reference, common shader patterns, and Shadertoy-specific conventions.
+description: This skill should be used when working with Shadertoy shaders, GLSL fragment shaders, or creating procedural graphics for the web. Use when writing .glsl files, implementing visual effects, creating generative art, debugging uniforms, optimizing render passes, or working with WebGL shader code. This skill provides GLSL ES syntax reference, common shader patterns (ray marching, distance fields, noise, palettes), Shadertoy-specific built-in variables, multi-pass rendering setup, and debugging and performance optimization techniques.
 ---
 
 # Shadertoy Shader Development
-
-## Overview
-
-Shadertoy is a platform for creating and sharing GLSL fragment shaders that run in the browser using WebGL. This skill provides comprehensive guidance for writing shaders including GLSL ES syntax, common patterns, mathematical techniques, and best practices specific to real-time procedural graphics.
-
-## When to Use This Skill
-
-Activate this skill when:
-- Writing or editing `.glsl` shader files
-- Creating procedural graphics, generative art, or visual effects
-- Working with Shadertoy.com projects or WebGL fragment shaders
-- Implementing ray marching, distance fields, or procedural textures
-- Debugging shader code or optimizing shader performance
-- Need GLSL ES syntax reference or Shadertoy input variables
 
 ## Core Concepts
 
@@ -56,13 +42,11 @@ Always available in shaders:
 Standard patterns for normalizing coordinates:
 
 ```glsl
-// Aspect-corrected UV centered at origin (-1 to 1, aspect-preserved)
-vec2 uv = (fragCoord.xy - 0.5 * iResolution.xy) / min(iResolution.y, iResolution.x);
-
-// Alternative compact form:
+// Aspect-corrected UV centered at origin (-1 to 1, aspect-preserved) — most common for 3D/ray marching
 vec2 uv = (fragCoord * 2.0 - iResolution.xy) / min(iResolution.x, iResolution.y);
+// Variant using max(y, x) in denominator keeps full height instead of full width in frame
 
-// Simple normalized (0 to 1)
+// Simple normalized (0 to 1) — useful for texture sampling and 2D effects
 vec2 uv = fragCoord / iResolution.xy;
 ```
 
@@ -249,10 +233,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
 1. **Set up coordinate system** - Choose appropriate UV normalization
 2. **Define core effect** - Implement main visual algorithm
-3. **Add animation** - Use `iTime` for temporal variation
-4. **Apply color palette** - Use cosine palette or custom scheme
-5. **Add post-processing** - Vignette, dither, gamma correction
-6. **Optimize** - Reduce iterations, use early exits, minimize branches
+3. **Validate GLSL ES compliance** - Check against Critical GLSL ES Rules above; confirm no `f` suffixes, no `saturate()`, no unguarded `pow`/`sqrt`, no uninitialized variables
+4. **Add animation** - Use `iTime` for temporal variation
+5. **Apply color palette** - Use cosine palette or custom scheme
+6. **Add post-processing** - Vignette, dither, gamma correction
+7. **Verify output** - Visualize intermediate values (normals, UVs, distance fields) to confirm correctness before final polish
+8. **Optimize** - Reduce iterations, use early exits, minimize branches
 
 ### Common Tasks
 
@@ -307,15 +293,6 @@ fragColor = vec4(fract(uv), 0.0, 1.0);       // Show UV tiling
 4. **Minimize texture reads** - Cache repeated lookups
 5. **Avoid conditionals** - Use `mix()`, `step()`, `smoothstep()` instead of `if`
 6. **Reduce precision** - Use `mediump` or `lowp` where appropriate (mobile)
-
-## Naming Conventions
-
-Based on observed patterns in creative work:
-
-- **Poetic/evocative names** - "alien-water", "heavenly-wisp", "comprehension"
-- **Technical descriptors** - "complex-plot", "noise-circuits", "ray-marching-demo"
-- **Compound phrases** - "coming-apart-at-the-seams", "form-without-form"
-- **Lowercase with hyphens** - `my-shader-name.glsl`
 
 ## Attribution and Forking
 
@@ -387,21 +364,3 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     fragColor = vec4(col, 1.0);
 }
 ```
-
-## Common Shader Types in Collection
-
-1. **Mathematical Visualizations** - Complex number plots, function graphs
-2. **Ray Marched 3D** - Distance field rendering, folded geometries
-3. **Procedural Textures** - Noise-based patterns, organic effects
-4. **Multi-Pass Effects** - Temporal feedback, buffer composition
-5. **Particle Systems** - Point-based simulations
-6. **2D Patterns** - Geometric, kaleidoscopic, interference effects
-
-## Tips for Creative Coding
-
-- **Start simple** - Get basic structure working, then iterate
-- **Use time creatively** - `sin(iTime)`, `mod(iTime, period)`, `smoothstep()` transitions
-- **Layer effects** - Combine multiple techniques for richness
-- **Embrace accidents** - Bugs often lead to interesting visuals
-- **Study references** - Learn from existing shaders, understand techniques
-- **Optimize later** - Prioritize visual quality first, then performance


### PR DESCRIPTION
@bfollington Hullo 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="1594" alt="terma_score_card" src="https://github.com/user-attachments/assets/072da9ea-c4ec-4290-9ded-8f4588a53a22" />

Here's the before/after in text form:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| implement | 31% | 96% | +65% |
| code-review | 52% | 94% | +42% |
| orient | 52% | 96% | +44% |
| plan | 49% | 93% | +44% |
| ideate | 52% | 89% | +37% |
| godot-interactive | 61% | 89% | +28% |
| sqlite-db | 74% | 96% | +22% |
| skill-improver | 76% | 93% | +17% |
| domain-driven-design | 76% | 93% | +17% |
| shadertoy | 81% | 93% | +12% |
| skill-networks | 0% | 89% | +89% |
| taking-an-idea-to-implementable-prototype | 0% | 89% | +89% | | writing-code | 0% | 96% | +96% |
| claude-plugins | 0% | 100% | +100% |

<details>
<summary>Changes made</summary>

**Skills that previously lacked frontmatter (skill-networks, taking-an-idea-to-implementable-prototype, writing-code, claude-plugins):**
- Added valid YAML frontmatter with descriptive `name` and `description` fields
- Added structured workflows, concrete examples, and validation checklists

**Stub skills expanded (code-review, ideate, implement, orient, plan):**
- Expanded frontmatter descriptions with specific actions and natural trigger terms
- Added inline workflows with numbered steps alongside existing `@../../lib/` references
- Added concrete output templates and validation gates

**Already-good skills refined (sqlite-db, skill-improver, domain-driven-design, godot-interactive, shadertoy):**
- Trimmed verbose philosophical/explanatory sections
- Condensed redundant prose and converted blocks to compact tables
- Removed sections duplicating frontmatter (redundant "When to Use", "Overview" sections)
- Added validation checkpoints to workflows

**Unchanged (no optimisation needed or already high-scoring):**
- sqlite-notes, research, skill-management, bevy, godot, pattrns, strudel

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

If you want to run reviews, evals and optimizations yourself, just `npm install @tessl/cli` then run `tessl skill review path/to/your/SKILL.md`, and click [here](https://tessl.io/registry/skills/submit) to find out more.

Thanks in advance 🙏